### PR TITLE
don't panic on non-UTF-8 output

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -54,8 +54,8 @@ pub fn build_dependencies(config: &Config) -> Result<Dependencies> {
     let output = build.output()?;
 
     if !output.status.success() {
-        let stdout = String::from_utf8(output.stdout)?;
-        let stderr = String::from_utf8(output.stderr)?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         bail!("failed to compile dependencies:\nstderr:\n{stderr}\n\nstdout:{stdout}");
     }
 
@@ -88,8 +88,8 @@ pub fn build_dependencies(config: &Config) -> Result<Dependencies> {
     let output = metadata.output()?;
 
     if !output.status.success() {
-        let stdout = String::from_utf8(output.stdout)?;
-        let stderr = String::from_utf8(output.stderr)?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         bail!("failed to run cargo-metadata:\nstderr:\n{stderr}\n\nstdout:{stdout}");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,7 +497,7 @@ fn check_test_result(
 ) -> String {
     // Always remove annotation comments from stderr.
     let diagnostics = rustc_stderr::process(path, stderr);
-    let stdout = std::str::from_utf8(stdout).unwrap();
+    let stdout = String::from_utf8_lossy(stdout);
     // Check output files (if any)
     let revised = |extension: &str| {
         if revision.is_empty() {
@@ -518,7 +518,7 @@ fn check_test_result(
         comments,
     );
     check_output(
-        stdout,
+        &stdout,
         path,
         errors,
         revised("stdout"),

--- a/src/rustc_stderr.rs
+++ b/src/rustc_stderr.rs
@@ -125,7 +125,7 @@ pub(crate) fn filter_annotations_from_rendered(rendered: &str) -> std::borrow::C
 }
 
 pub(crate) fn process(file: &Path, stderr: &[u8]) -> Diagnostics {
-    let stderr = std::str::from_utf8(stderr).unwrap();
+    let stderr = String::from_utf8_lossy(stderr);
     let mut rendered = String::new();
     let mut messages = vec![];
     let mut messages_from_unknown_file_or_line = vec![];


### PR DESCRIPTION
This won't let us actually ensure that non-UTF-8 output exactly matches the reference (basically all non-UTF-8 is normalized through the 'lossy' functions), but it will at least not panic.

Helps with https://github.com/oli-obk/ui_test/issues/14