### PR TITLE
Add semver checks to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,8 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  style:
-    name: style checks
+  fmt:
+    name: check rustfmt
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -19,12 +19,37 @@ jobs:
       with:
         toolchain: 1.63.0
         profile: minimal
-        components: rustfmt, clippy
+        components: rustfmt
         override: true
     - name: Format
       run: cargo fmt --check
+
+  clippy:
+    name: check clippy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.63.0
+        profile: minimal
+        components: clippy
+        override: true
     - name: Clippy
       run: cargo clippy -- -D warnings
+  
+  semver:
+    name: semver
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v1
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
using https://github.com/obi1kenobi/cargo-semver-check to automatically fail CI if a change is done without the appropriate `Cargo.toml` version bump