### PR TITLE
Make run-rustfix a full Mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bstr",
  "cargo-platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui_test"
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A test framework for testing rustc diagnostics output"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -76,7 +76,6 @@ pub(crate) struct Revisioned {
     /// Ignore diagnostics below this level.
     /// `None` means pick the lowest level from the `error_pattern`s.
     pub require_annotations_for_level: Option<Level>,
-    pub run_rustfix: bool,
     pub aux_builds: Vec<(PathBuf, String)>,
     pub edition: Option<(String, usize)>,
     /// Overwrites the mode from `Config`.
@@ -373,8 +372,11 @@ impl CommentParser<&mut Revisioned> {
             }
             "run-rustfix" => {
                 // args are ignored (can be used as comment)
-                self.check(!self.run_rustfix, "cannot specify `run-rustfix` twice");
-                self.run_rustfix = true;
+                self.check(
+                    self.mode.is_none(),
+                    "cannot specify test mode changes twice",
+                );
+                self.mode = Some((Mode::Fix, self.line))
             }
             "needs-asm-support" => {
                 // args are ignored (can be used as comment)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -93,7 +93,7 @@ fn run(name: &str, mode: Mode) -> Result<()> {
                     // multiple [[test]]s exist. If there's only one test, it returns
                     // 1 on failure.
                     Mode::Panic => fail,
-                    Mode::Run { .. } | Mode::Yolo | Mode::Fail { .. } => unreachable!(),
+                    Mode::Fix | Mode::Run { .. } | Mode::Yolo | Mode::Fail { .. } => unreachable!(),
                 }
         },
         |_, _| None,

--- a/tests/integrations/basic-bin/Cargo.lock
+++ b/tests/integrations/basic-bin/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bstr",
  "cargo-platform",

--- a/tests/integrations/basic-fail-mode/Cargo.lock
+++ b/tests/integrations/basic-fail-mode/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bstr",
  "cargo-platform",

--- a/tests/integrations/basic-fail/Cargo.lock
+++ b/tests/integrations/basic-fail/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bstr",
  "cargo-platform",

--- a/tests/integrations/basic/Cargo.lock
+++ b/tests/integrations/basic/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bstr",
  "cargo-platform",


### PR DESCRIPTION
Using Mode for `run-pass` made me realize that `run-rustfix` is also just a mode