### PR TITLE
Add env var to distinguish rustc aux vs test runs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -835,6 +835,7 @@ fn run_test(
         &mut errors,
     );
     cmd.args(&extra_args);
+    cmd.env("UITEST_TEST_RUN", "True");
 
     let output = cmd
         .output()

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -7,7 +7,7 @@ tests/actual_tests/filters.rs ... FAILED
 tests/actual_tests/foomp.rs ... FAILED
 
 tests/actual_tests/bad_pattern.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/bad_pattern.rs" "--edition" "2021"
+command: UITEST_TEST_RUN="True" "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/bad_pattern.rs" "--edition" "2021"
 
 substring `miesmätsched types` not found in stderr output
 expected because of pattern here: tests/actual_tests/bad_pattern.rs:5
@@ -52,7 +52,7 @@ full stderr:
 
 
 tests/actual_tests/executable_compile_err.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/executable_compile_err.rs" "--edition" "2021"
+command: UITEST_TEST_RUN="True" "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/executable_compile_err.rs" "--edition" "2021"
 
 run(0) test got exit status: 1, but expected 0
 
@@ -90,7 +90,7 @@ error: aborting due to previous error
 
 
 tests/actual_tests/exit_code_fail.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/exit_code_fail.rs" "--edition" "2021"
+command: UITEST_TEST_RUN="True" "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/exit_code_fail.rs" "--edition" "2021"
 
 fail test got exit status: 0, but expected 1
 
@@ -111,7 +111,7 @@ full stderr:
 
 
 tests/actual_tests/foomp.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/foomp.rs" "--edition" "2021"
+command: UITEST_TEST_RUN="True" "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/foomp.rs" "--edition" "2021"
 
 actual output differed from expected
 --- tests/actual_tests/foomp.stderr
@@ -342,7 +342,7 @@ full stderr:
 
 
 tests/actual_tests_bless/revisioned_executable.rs (revision `panic`) FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisioned_executable.rs" "--cfg=panic" "--edition" "2021"
+command: UITEST_TEST_RUN="True" "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisioned_executable.rs" "--cfg=panic" "--edition" "2021"
 
 run(101) test got exit status: 0, but expected 101
 
@@ -360,7 +360,7 @@ full stderr:
 
 
 tests/actual_tests_bless/revisioned_executable_panic.rs (revision `panic`) FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisioned_executable_panic.rs" "--cfg=panic" "--edition" "2021"
+command: UITEST_TEST_RUN="True" "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisioned_executable_panic.rs" "--cfg=panic" "--edition" "2021"
 
 run(101) test got exit status: 0, but expected 101
 
@@ -369,7 +369,7 @@ full stderr:
 
 
 tests/actual_tests_bless/revisions_bad.rs (revision `bar`) FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisions_bad.rs" "--cfg=bar" "--edition" "2021"
+command: UITEST_TEST_RUN="True" "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisions_bad.rs" "--cfg=bar" "--edition" "2021"
 
 substring ``main` function not found in crate `revisions_bad`` not found in stderr output
 expected because of pattern here: tests/actual_tests_bless/revisions_bad.rs:4
@@ -410,7 +410,7 @@ tests/actual_tests_bless_yolo/revisions_bad.rs (foo) ... ok
 tests/actual_tests_bless_yolo/revisions_bad.rs (bar) ... FAILED
 
 tests/actual_tests_bless_yolo/revisions_bad.rs (revision `bar`) FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless_yolo/revisions_bad.rs" "--cfg=bar" "--edition" "2021"
+command: UITEST_TEST_RUN="True" "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless_yolo/revisions_bad.rs" "--cfg=bar" "--edition" "2021"
 
 substring ``main` function not found in crate `revisions_bad`` not found in stderr output
 expected because of pattern here: tests/actual_tests_bless_yolo/revisions_bad.rs:4
@@ -449,23 +449,23 @@ error: test failed, to rerun pass `--test ui_tests_invalid_program`
 
 Caused by:
   process didn't exit successfully: `$DIR/target/debug/ui_tests_invalid_program-HASH --test-threads 1` (exit status: 1)
-thread '<unnamed>' panicked at 'could not execute "invalid_foobarlaksdfalsdfj" "tests/actual_tests/bad_pattern.rs" "--edition" "2021"', $DIR/src/lib.rs
+thread '<unnamed>' panicked at 'could not execute UITEST_TEST_RUN="True" "invalid_foobarlaksdfalsdfj" "tests/actual_tests/bad_pattern.rs" "--edition" "2021"', $DIR/src/lib.rs
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 tests/actual_tests/bad_pattern.rs ... FAILED
-thread '<unnamed>' panicked at 'could not execute "invalid_foobarlaksdfalsdfj" "tests/actual_tests/executable.rs" "--edition" "2021"', $DIR/src/lib.rs
+thread '<unnamed>' panicked at 'could not execute UITEST_TEST_RUN="True" "invalid_foobarlaksdfalsdfj" "tests/actual_tests/executable.rs" "--edition" "2021"', $DIR/src/lib.rs
 tests/actual_tests/executable.rs ... FAILED
-thread '<unnamed>' panicked at 'could not execute "invalid_foobarlaksdfalsdfj" "tests/actual_tests/executable_compile_err.rs" "--edition" "2021"', $DIR/src/lib.rs
+thread '<unnamed>' panicked at 'could not execute UITEST_TEST_RUN="True" "invalid_foobarlaksdfalsdfj" "tests/actual_tests/executable_compile_err.rs" "--edition" "2021"', $DIR/src/lib.rs
 tests/actual_tests/executable_compile_err.rs ... FAILED
-thread '<unnamed>' panicked at 'could not execute "invalid_foobarlaksdfalsdfj" "tests/actual_tests/exit_code_fail.rs" "--edition" "2021"', $DIR/src/lib.rs
+thread '<unnamed>' panicked at 'could not execute UITEST_TEST_RUN="True" "invalid_foobarlaksdfalsdfj" "tests/actual_tests/exit_code_fail.rs" "--edition" "2021"', $DIR/src/lib.rs
 tests/actual_tests/exit_code_fail.rs ... FAILED
 tests/actual_tests/filters.rs ... FAILED
-thread '<unnamed>' panicked at 'could not execute "invalid_foobarlaksdfalsdfj" "tests/actual_tests/foomp.rs" "--edition" "2021"', $DIR/src/lib.rs
+thread '<unnamed>' panicked at 'could not execute UITEST_TEST_RUN="True" "invalid_foobarlaksdfalsdfj" "tests/actual_tests/foomp.rs" "--edition" "2021"', $DIR/src/lib.rs
 tests/actual_tests/foomp.rs ... FAILED
 
 tests/actual_tests/bad_pattern.rs FAILED:
 command: "<unknown>"
 
-A bug in `ui_test` occurred: could not execute "invalid_foobarlaksdfalsdfj" "tests/actual_tests/bad_pattern.rs" "--edition" "2021"
+A bug in `ui_test` occurred: could not execute UITEST_TEST_RUN="True" "invalid_foobarlaksdfalsdfj" "tests/actual_tests/bad_pattern.rs" "--edition" "2021"
 
 full stderr:
 
@@ -474,7 +474,7 @@ full stderr:
 tests/actual_tests/executable.rs FAILED:
 command: "<unknown>"
 
-A bug in `ui_test` occurred: could not execute "invalid_foobarlaksdfalsdfj" "tests/actual_tests/executable.rs" "--edition" "2021"
+A bug in `ui_test` occurred: could not execute UITEST_TEST_RUN="True" "invalid_foobarlaksdfalsdfj" "tests/actual_tests/executable.rs" "--edition" "2021"
 
 full stderr:
 
@@ -483,7 +483,7 @@ full stderr:
 tests/actual_tests/executable_compile_err.rs FAILED:
 command: "<unknown>"
 
-A bug in `ui_test` occurred: could not execute "invalid_foobarlaksdfalsdfj" "tests/actual_tests/executable_compile_err.rs" "--edition" "2021"
+A bug in `ui_test` occurred: could not execute UITEST_TEST_RUN="True" "invalid_foobarlaksdfalsdfj" "tests/actual_tests/executable_compile_err.rs" "--edition" "2021"
 
 full stderr:
 
@@ -492,7 +492,7 @@ full stderr:
 tests/actual_tests/exit_code_fail.rs FAILED:
 command: "<unknown>"
 
-A bug in `ui_test` occurred: could not execute "invalid_foobarlaksdfalsdfj" "tests/actual_tests/exit_code_fail.rs" "--edition" "2021"
+A bug in `ui_test` occurred: could not execute UITEST_TEST_RUN="True" "invalid_foobarlaksdfalsdfj" "tests/actual_tests/exit_code_fail.rs" "--edition" "2021"
 
 full stderr:
 
@@ -511,7 +511,7 @@ full stderr:
 tests/actual_tests/foomp.rs FAILED:
 command: "<unknown>"
 
-A bug in `ui_test` occurred: could not execute "invalid_foobarlaksdfalsdfj" "tests/actual_tests/foomp.rs" "--edition" "2021"
+A bug in `ui_test` occurred: could not execute UITEST_TEST_RUN="True" "invalid_foobarlaksdfalsdfj" "tests/actual_tests/foomp.rs" "--edition" "2021"
 
 full stderr:
 
@@ -533,8 +533,22 @@ error: test failed, to rerun pass `--test ui_tests_invalid_program2`
 
 Caused by:
   process didn't exit successfully: `$DIR/target/debug/ui_tests_invalid_program2-HASH --test-threads 1` (exit status: 1)
-error: 4 targets failed:
+   Compiler: ../runner.py
+Error: failed to parse rustc version info: ../runner.py
+
+Caused by:
+
+
+
+Location:
+    $DIR/src/lib.rs:175:21
+error: test failed, to rerun pass `--test ui_tests_with_wrapper_script`
+
+Caused by:
+  process didn't exit successfully: `$DIR/target/debug/ui_tests_with_wrapper_script-HASH --test-threads 1` (exit status: 1)
+error: 5 targets failed:
     `--test ui_tests`
     `--test ui_tests_bless`
     `--test ui_tests_invalid_program`
     `--test ui_tests_invalid_program2`
+    `--test ui_tests_with_wrapper_script`

--- a/tests/integrations/basic-fail/Cargo.toml
+++ b/tests/integrations/basic-fail/Cargo.toml
@@ -24,3 +24,7 @@ harness = false
 [[test]]
 name = "ui_tests_bless"
 harness = false
+
+[[test]]
+name = "ui_tests_with_wrapper_script"
+harness = false

--- a/tests/integrations/basic-fail/tests/ui_tests_with_wrapper_script.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_with_wrapper_script.rs
@@ -1,0 +1,17 @@
+use std::num::NonZeroUsize;
+use ui_test::*;
+
+fn main() -> ui_test::color_eyre::Result<()> {
+    let config = Config {
+        quiet: false,
+        program: CommandBuilder::cmd("../runner.py"),
+        root_dir: "tests/actual_tests".into(),
+        // Never bless integrations-fail tests, we want to see stderr mismatches
+        output_conflict_handling: OutputConflictHandling::Error,
+        // Make sure our tests are ordered for reliable output.
+        num_test_threads: NonZeroUsize::new(1).unwrap(),
+        ..Config::default()
+    };
+
+    ui_test::run_tests(config)
+}

--- a/tests/integrations/basic/Cargo.stdout
+++ b/tests/integrations/basic/Cargo.stdout
@@ -13,3 +13,8 @@ running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished 
 
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished 
+

--- a/tests/integrations/basic/Cargo.toml
+++ b/tests/integrations/basic/Cargo.toml
@@ -14,5 +14,9 @@ name = "ui_tests"
 harness = false
 
 [[test]]
+name = "ui_tests_with_wrapper_script"
+harness = false
+
+[[test]]
 name = "run_file"
 harness = true

--- a/tests/integrations/basic/tests/ui_tests_with_wrapper_script.rs
+++ b/tests/integrations/basic/tests/ui_tests_with_wrapper_script.rs
@@ -1,0 +1,17 @@
+use std::num::NonZeroUsize;
+use ui_test::*;
+
+fn main() -> ui_test::color_eyre::Result<()> {
+    let config = Config {
+        quiet: false,
+        program: CommandBuilder::cmd("../runner.py"),
+        root_dir: "tests/actual_tests".into(),
+        // Never bless integrations-fail tests, we want to see stderr mismatches
+        output_conflict_handling: OutputConflictHandling::Error,
+        // Make sure our tests are ordered for reliable output.
+        num_test_threads: NonZeroUsize::new(1).unwrap(),
+        ..Config::default()
+    };
+
+    ui_test::run_tests(config)
+}

--- a/tests/integrations/runner.py
+++ b/tests/integrations/runner.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+import os
+
+args = sys.argv[1:]
+
+# Make sure args is non-empty
+if not args:
+    print("Error: no arguments provided for rustc")
+    sys.exit(1)
+
+# Call rustc with the arguments
+try:
+    rustc_args = ["rustc"] + args
+    subprocess.run(rustc_args, check=True)
+except subprocess.CalledProcessError as e:
+    sys.exit(e.returncode)
+
+#is_test_run = os.getenv("UITEST_TEST_RUN", "False") == "True"
+#if is_test_run:
+    # In real-life use-cases, you might do something here


### PR DESCRIPTION
This patch just adds an env variable that scripts that wrap rustc can look at to know whether this is the actual test run itself, or just an auxilary call to rustc to gather some metadata.