### PR TITLE
Provide a command for running a single test instead of running it directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bstr",
  "cargo-platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui_test"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A test framework for testing rustc diagnostics output"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 
 use bstr::ByteSlice;
 pub use color_eyre;
-use color_eyre::eyre::{eyre, Context, Result};
+use color_eyre::eyre::{eyre, Result};
 use crossbeam_channel::unbounded;
 use parser::{ErrorMatch, Pattern, Revisioned};
 use regex::bytes::Regex;
@@ -357,7 +357,7 @@ pub fn run_tests(config: Config) -> Result<()> {
 
 /// Run a single file, with the settings from the `config` argument. Ignores various
 /// settings from `Config` that relate to finding test files.
-pub fn run_file(mut config: Config, path: &Path) -> Result<std::process::Output> {
+pub fn run_file(mut config: Config, path: &Path) -> Result<Command> {
     config.build_dependencies_and_link_them()?;
 
     let comments =
@@ -370,16 +370,9 @@ pub fn run_file(mut config: Config, path: &Path) -> Result<std::process::Output>
         &comments,
         config.out_dir.as_deref(),
         &mut errors,
-    )
-    .output()
-    .wrap_err_with(|| {
-        format!(
-            "path `{}` is not an executable",
-            config.program.program.display()
-        )
-    });
+    );
     assert!(errors.is_empty(), "{errors:#?}");
-    result
+    Ok(result)
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,9 +355,9 @@ pub fn run_tests(config: Config) -> Result<()> {
     )
 }
 
-/// Run a single file, with the settings from the `config` argument. Ignores various
-/// settings from `Config` that relate to finding test files.
-pub fn run_file(mut config: Config, path: &Path) -> Result<Command> {
+/// Create a command for running a single file, with the settings from the `config` argument.
+/// Ignores various settings from `Config` that relate to finding test files.
+pub fn test_command(mut config: Config, path: &Path) -> Result<Command> {
     config.build_dependencies_and_link_them()?;
 
     let comments =

--- a/tests/integrations/basic-bin/Cargo.lock
+++ b/tests/integrations/basic-bin/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bstr",
  "cargo-platform",

--- a/tests/integrations/basic-fail-mode/Cargo.lock
+++ b/tests/integrations/basic-fail-mode/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bstr",
  "cargo-platform",

--- a/tests/integrations/basic-fail-mode/tests/run_file.rs
+++ b/tests/integrations/basic-fail-mode/tests/run_file.rs
@@ -9,7 +9,7 @@ fn run_file() -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
     config.out_dir = Some(tmp_dir.path().into());
 
-    let mut result = ui_test::run_file(
+    let mut result = ui_test::test_command(
         config,
         &Path::new(file!())
             .parent()
@@ -25,7 +25,7 @@ fn fail_run_file() {
     let mut config = Config::default();
     config.program = CommandBuilder::cmd("invalid_alsdkfjalsdfjalskdfj");
 
-    let _ = ui_test::run_file(
+    let _ = ui_test::test_command(
         config,
         &Path::new(file!())
             .parent()
@@ -54,7 +54,7 @@ fn run_file_no_deps() -> Result<()> {
         .envs
         .push(("CARGO_TARGET_DIR".into(), Some(path.into())));
 
-    let mut result = ui_test::run_file(
+    let mut result = ui_test::test_command(
         config,
         &Path::new(file!())
             .parent()

--- a/tests/integrations/basic-fail-mode/tests/run_file.rs
+++ b/tests/integrations/basic-fail-mode/tests/run_file.rs
@@ -9,14 +9,14 @@ fn run_file() -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
     config.out_dir = Some(tmp_dir.path().into());
 
-    let result = ui_test::run_file(
+    let mut result = ui_test::run_file(
         config,
         &Path::new(file!())
             .parent()
             .unwrap()
             .join("run_file/run_file.rs"),
     )?;
-    ensure!(result.status.success(), "");
+    ensure!(result.output()?.status.success(), "");
     Ok(())
 }
 
@@ -32,6 +32,8 @@ fn fail_run_file() {
             .unwrap()
             .join("run_file/run_file.rs"),
     )
+    .unwrap()
+    .output()
     .unwrap_err();
 }
 
@@ -52,13 +54,13 @@ fn run_file_no_deps() -> Result<()> {
         .envs
         .push(("CARGO_TARGET_DIR".into(), Some(path.into())));
 
-    let result = ui_test::run_file(
+    let mut result = ui_test::run_file(
         config,
         &Path::new(file!())
             .parent()
             .unwrap()
             .join("run_file/run_file_with_deps.rs"),
     )?;
-    ensure!(result.status.success(), "");
+    ensure!(result.output()?.status.success(), "");
     Ok(())
 }

--- a/tests/integrations/basic-fail/Cargo.lock
+++ b/tests/integrations/basic-fail/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bstr",
  "cargo-platform",

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -167,7 +167,7 @@ test result: FAIL. 6 tests failed, 0 tests passed, 0 ignored, 0 filtered out
 Error: tests failed
 
 Location:
-    $DIR/src/lib.rs:549:13
+    $DIR/src/lib.rs:542:13
 error: test failed, to rerun pass `--test ui_tests`
 
 Caused by:
@@ -434,7 +434,7 @@ test result: FAIL. 1 tests failed, 2 tests passed, 0 ignored, 0 filtered out
 thread 'main' panicked at 'invalid mode/result combo: yolo: Err(tests failed
 
 Location:
-    $DIR/src/lib.rs:549:13)', tests/ui_tests_bless.rs:56:18
+    $DIR/src/lib.rs:542:13)', tests/ui_tests_bless.rs:56:18
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: test failed, to rerun pass `--test ui_tests_bless`
 Error: failed to parse rustc version info: invalid_foobarlaksdfalsdfj
@@ -528,7 +528,7 @@ test result: FAIL. 6 tests failed, 0 tests passed, 0 ignored, 0 filtered out
 Error: tests failed
 
 Location:
-    $DIR/src/lib.rs:549:13
+    $DIR/src/lib.rs:542:13
 error: test failed, to rerun pass `--test ui_tests_invalid_program2`
 
 Caused by:

--- a/tests/integrations/basic/Cargo.lock
+++ b/tests/integrations/basic/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bstr",
  "cargo-platform",

--- a/tests/integrations/basic/tests/run_file.rs
+++ b/tests/integrations/basic/tests/run_file.rs
@@ -9,14 +9,14 @@ fn run_file() -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
     config.out_dir = Some(tmp_dir.path().into());
 
-    let result = ui_test::run_file(
+    let mut result = ui_test::run_file(
         config,
         &Path::new(file!())
             .parent()
             .unwrap()
             .join("run_file/run_file.rs"),
     )?;
-    ensure!(result.status.success(), "");
+    ensure!(result.output()?.status.success(), "");
     Ok(())
 }
 
@@ -37,14 +37,14 @@ fn run_file_with_deps() -> Result<()> {
         .envs
         .push(("CARGO_TARGET_DIR".into(), Some(path.into())));
 
-    let result = ui_test::run_file(
+    let mut result = ui_test::run_file(
         config,
         &Path::new(file!())
             .parent()
             .unwrap()
             .join("run_file/run_file_with_deps.rs"),
     )?;
-    ensure!(result.status.success(), "");
+    ensure!(result.output()?.status.success(), "");
     Ok(())
 }
 
@@ -61,7 +61,7 @@ fn non_utf8() -> Result<()> {
     config.program = CommandBuilder::cmd("cat");
     config.edition = None;
 
-    let result = ui_test::run_file(config, &path)?;
-    ensure!(result.status.success(), "");
+    let mut result = ui_test::run_file(config, &path)?;
+    ensure!(result.output()?.status.success(), "");
     Ok(())
 }

--- a/tests/integrations/basic/tests/run_file.rs
+++ b/tests/integrations/basic/tests/run_file.rs
@@ -9,7 +9,7 @@ fn run_file() -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
     config.out_dir = Some(tmp_dir.path().into());
 
-    let mut result = ui_test::run_file(
+    let mut result = ui_test::test_command(
         config,
         &Path::new(file!())
             .parent()
@@ -37,7 +37,7 @@ fn run_file_with_deps() -> Result<()> {
         .envs
         .push(("CARGO_TARGET_DIR".into(), Some(path.into())));
 
-    let mut result = ui_test::run_file(
+    let mut result = ui_test::test_command(
         config,
         &Path::new(file!())
             .parent()
@@ -61,7 +61,7 @@ fn non_utf8() -> Result<()> {
     config.program = CommandBuilder::cmd("cat");
     config.edition = None;
 
-    let mut result = ui_test::run_file(config, &path)?;
+    let mut result = ui_test::test_command(config, &path)?;
     ensure!(result.output()?.status.success(), "");
     Ok(())
 }


### PR DESCRIPTION
This allows callers to choose how they get their output