### PR TITLE
Show the command that should be run to fix any test failures

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -60,7 +60,7 @@ pub fn build_dependencies(config: &mut Config) -> Result<Dependencies> {
         cmd.arg("--manifest-path").arg(manifest_path);
         match (&config.output_conflict_handling, &config.mode) {
             (_, Mode::Yolo) => {}
-            (OutputConflictHandling::Error, _) => {
+            (OutputConflictHandling::Error(_), _) => {
                 cmd.arg("--locked");
             }
             _ => {}

--- a/src/status_emitter.rs
+++ b/src/status_emitter.rs
@@ -204,8 +204,14 @@ fn print_error(error: &Error, path: &str) {
             path: output_path,
             actual,
             expected,
+            bless_command,
         } => {
             eprintln!("{}", "actual output differed from expected".underline());
+            eprintln!(
+                "Execute `{}` to update `{}` to the actual output",
+                bless_command,
+                output_path.display()
+            );
             eprintln!("{}", format!("--- {}", output_path.display()).red());
             eprintln!("{}", "+++ <stderr output>".green());
             crate::diff::print_diff(expected, actual);
@@ -287,6 +293,7 @@ fn gha_error(error: &Error, path: &str, revision: &str) {
             path: output_path,
             actual,
             expected,
+            bless_command: _,
         } => {
             let mut err = github_actions::error(
                 if expected.is_empty() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -22,15 +22,14 @@ fn run(name: &str, mode: Mode) -> Result<()> {
         root_dir: root_dir.clone(),
         trailing_args: vec!["--".into(), "--test-threads".into(), "1".into()],
         program: CommandBuilder::cmd("cargo"),
-        output_conflict_handling: if bless {
-            OutputConflictHandling::Bless
-        } else {
-            OutputConflictHandling::Error
-        },
         mode,
         edition: None,
         ..Config::default()
     };
+
+    if bless {
+        config.output_conflict_handling = OutputConflictHandling::Bless;
+    }
 
     config.program.args = vec![
         "test".into(),

--- a/tests/integrations/basic-bin/tests/ui_tests.rs
+++ b/tests/integrations/basic-bin/tests/ui_tests.rs
@@ -6,13 +6,11 @@ fn main() -> ui_test::color_eyre::Result<()> {
         quiet: false,
         root_dir: "tests/actual_tests".into(),
         dependencies_crate_manifest_path: Some("Cargo.toml".into()),
-        output_conflict_handling: if std::env::var_os("BLESS").is_some() {
-            OutputConflictHandling::Bless
-        } else {
-            OutputConflictHandling::Error
-        },
         ..Config::default()
     };
+    if std::env::var_os("BLESS").is_some() {
+        config.output_conflict_handling = OutputConflictHandling::Bless
+    }
     config
         .dependency_builder
         .envs

--- a/tests/integrations/basic-fail-mode/tests/ui_tests.rs
+++ b/tests/integrations/basic-fail-mode/tests/ui_tests.rs
@@ -6,16 +6,14 @@ fn main() -> ui_test::color_eyre::Result<()> {
         quiet: false,
         root_dir: "tests/actual_tests".into(),
         dependencies_crate_manifest_path: Some("Cargo.toml".into()),
-        output_conflict_handling: if std::env::var_os("BLESS").is_some() {
-            OutputConflictHandling::Bless
-        } else {
-            OutputConflictHandling::Error
-        },
         mode: Mode::Fail {
             require_patterns: true,
         },
         ..Config::default()
     };
+    if std::env::var_os("BLESS").is_some() {
+        config.output_conflict_handling = OutputConflictHandling::Bless
+    }
     config
         .dependency_builder
         .envs
@@ -24,7 +22,7 @@ fn main() -> ui_test::color_eyre::Result<()> {
     config.stdout_filter("in ([0-9]m )?[0-9\\.]+s", "");
     config.stderr_filter(r"[^ ]*/\.?cargo/registry/.*/", "$$CARGO_REGISTRY");
     config.path_stderr_filter(&std::path::Path::new(path), "$DIR");
-    
+
     ui_test::run_tests_generic(
         config,
         |path| path.extension().map(|ext| ext == "rs").unwrap_or(false),

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -40,6 +40,7 @@ tests/actual_tests/executable.rs FAILED:
 command: "$CMD"
 
 actual output differed from expected
+Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/executable.stdout` to the actual output
 --- tests/actual_tests/executable.stdout
 +++ <stderr output>
 -69
@@ -57,6 +58,7 @@ command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../..
 run(0) test got exit status: 1, but expected 0
 
 actual output differed from expected
+Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/executable_compile_err.stderr` to the actual output
 --- tests/actual_tests/executable_compile_err.stderr
 +++ <stderr output>
 +error: this file contains an unclosed delimiter
@@ -114,6 +116,7 @@ tests/actual_tests/foomp.rs FAILED:
 command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/foomp.rs" "--edition" "2021"
 
 actual output differed from expected
+Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/foomp.stderr` to the actual output
 --- tests/actual_tests/foomp.stderr
 +++ <stderr output>
 ... 3 lines skipped ...
@@ -167,7 +170,7 @@ test result: FAIL. 6 tests failed, 0 tests passed, 0 ignored, 0 filtered out
 Error: tests failed
 
 Location:
-    $DIR/src/lib.rs:542:13
+    $DIR/src/lib.rs:549:13
 error: test failed, to rerun pass `--test ui_tests`
 
 Caused by:
@@ -434,7 +437,7 @@ test result: FAIL. 1 tests failed, 2 tests passed, 0 ignored, 0 filtered out
 thread 'main' panicked at 'invalid mode/result combo: yolo: Err(tests failed
 
 Location:
-    $DIR/src/lib.rs:542:13)', tests/ui_tests_bless.rs:56:18
+    $DIR/src/lib.rs:549:13)', tests/ui_tests_bless.rs:54:18
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: test failed, to rerun pass `--test ui_tests_bless`
 Error: failed to parse rustc version info: invalid_foobarlaksdfalsdfj
@@ -444,7 +447,7 @@ Caused by:
 
 
 Location:
-    $DIR/src/lib.rs:175:21
+    $DIR/src/lib.rs:180:21
 error: test failed, to rerun pass `--test ui_tests_invalid_program`
 
 Caused by:
@@ -528,7 +531,7 @@ test result: FAIL. 6 tests failed, 0 tests passed, 0 ignored, 0 filtered out
 Error: tests failed
 
 Location:
-    $DIR/src/lib.rs:542:13
+    $DIR/src/lib.rs:549:13
 error: test failed, to rerun pass `--test ui_tests_invalid_program2`
 
 Caused by:

--- a/tests/integrations/basic-fail/tests/ui_tests.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests.rs
@@ -8,7 +8,9 @@ fn main() -> ui_test::color_eyre::Result<()> {
         root_dir: "tests/actual_tests".into(),
         dependencies_crate_manifest_path: Some("Cargo.toml".into()),
         // Never bless integrations-fail tests, we want to see stderr mismatches
-        output_conflict_handling: OutputConflictHandling::Error,
+        output_conflict_handling: OutputConflictHandling::Error(
+            "DO NOT BLESS. These are meant to fail".into(),
+        ),
         // Make sure our tests are ordered for reliable output.
         num_test_threads: NonZeroUsize::new(1).unwrap(),
         ..Config::default()
@@ -26,7 +28,7 @@ fn main() -> ui_test::color_eyre::Result<()> {
     config.stdout_filter("in ([0-9]m )?[0-9\\.]+s", "");
     config.stderr_filter(r"[^ ]*/\.?cargo/registry/.*/", "$$CARGO_REGISTRY");
     config.path_stderr_filter(&std::path::Path::new(path), "$DIR");
-    
+
     ui_test::run_tests_generic(
         config,
         |path| path.extension().map(|ext| ext == "rs").unwrap_or(false),

--- a/tests/integrations/basic-fail/tests/ui_tests_bless.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_bless.rs
@@ -20,16 +20,14 @@ fn main() -> ui_test::color_eyre::Result<()> {
             quiet: false,
             root_dir: root_dir.into(),
             dependencies_crate_manifest_path: Some("Cargo.toml".into()),
-            output_conflict_handling: if std::env::var_os("BLESS").is_some() {
-                OutputConflictHandling::Bless
-            } else {
-                OutputConflictHandling::Error
-            },
             // Make sure our tests are ordered for reliable output.
             num_test_threads: NonZeroUsize::new(1).unwrap(),
             mode,
             ..Config::default()
         };
+        if std::env::var_os("BLESS").is_some() {
+            config.output_conflict_handling = OutputConflictHandling::Bless
+        }
         config
             .dependency_builder
             .envs

--- a/tests/integrations/basic-fail/tests/ui_tests_invalid_program.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_invalid_program.rs
@@ -7,7 +7,9 @@ fn main() -> ui_test::color_eyre::Result<()> {
         program: CommandBuilder::cmd("invalid_foobarlaksdfalsdfj"),
         root_dir: "tests/actual_tests".into(),
         // Never bless integrations-fail tests, we want to see stderr mismatches
-        output_conflict_handling: OutputConflictHandling::Error,
+        output_conflict_handling: OutputConflictHandling::Error(
+            "DO NOT BLESS. These are meant to fail".into(),
+        ),
         // Make sure our tests are ordered for reliable output.
         num_test_threads: NonZeroUsize::new(1).unwrap(),
         ..Config::default()

--- a/tests/integrations/basic-fail/tests/ui_tests_invalid_program2.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_invalid_program2.rs
@@ -8,7 +8,9 @@ fn main() -> ui_test::color_eyre::Result<()> {
         root_dir: "tests/actual_tests".into(),
         host: Some("foo".into()),
         // Never bless integrations-fail tests, we want to see stderr mismatches
-        output_conflict_handling: OutputConflictHandling::Error,
+        output_conflict_handling: OutputConflictHandling::Error(
+            "DO NOT BLESS. These are meant to fail".into(),
+        ),
         // Make sure our tests are ordered for reliable output.
         num_test_threads: NonZeroUsize::new(1).unwrap(),
         ..Config::default()

--- a/tests/integrations/basic/tests/ui_tests.rs
+++ b/tests/integrations/basic/tests/ui_tests.rs
@@ -7,14 +7,12 @@ fn main() -> ui_test::color_eyre::Result<()> {
         quiet: false,
         root_dir: "tests/actual_tests".into(),
         dependencies_crate_manifest_path: Some("Cargo.toml".into()),
-        output_conflict_handling: if std::env::var_os("BLESS").is_some() {
-            OutputConflictHandling::Bless
-        } else {
-            OutputConflictHandling::Error
-        },
         num_test_threads: NonZeroUsize::new(1).unwrap(),
         ..Config::default()
     };
+    if std::env::var_os("BLESS").is_some() {
+        config.output_conflict_handling = OutputConflictHandling::Bless;
+    }
     config
         .dependency_builder
         .envs


### PR DESCRIPTION
The command differs from user to user. E.g. miri uses `./miri bless`, while most other users use `cargo test -- -- --bless` or `env BLESS=1 cargo test`