### PR TITLE
Handle out-dir setting per command

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -20,7 +20,7 @@ pub struct Dependencies {
 }
 
 fn cfgs(config: &Config) -> Result<Vec<Cfg>> {
-    let mut cmd = config.cfgs.build();
+    let mut cmd = config.cfgs.build(&config.out_dir);
     cmd.arg("--target").arg(config.target.as_ref().unwrap());
     let output = cmd.output()?;
     let stdout = String::from_utf8(output.stdout)?;
@@ -49,7 +49,7 @@ pub fn build_dependencies(config: &mut Config) -> Result<Dependencies> {
     let manifest_path = &manifest_path;
     config.fill_host_and_target()?;
     eprintln!("   Building test dependencies...");
-    let mut build = config.dependency_builder.build();
+    let mut build = config.dependency_builder.build(&config.out_dir);
 
     if let Some(target) = &config.target {
         build.arg(format!("--target={target}"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,7 +779,7 @@ fn build_aux(
     // Put aux builds into a separate directory per test so that
     // tests running in parallel but building the same aux build don't conflict.
     // FIXME: put aux builds into the regular build queue.
-    config.out_dir = config.out_dir.clone().join(path.with_extension(""));
+    config.out_dir = config.out_dir.join(path.with_extension(""));
 
     let mut errors = vec![];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,8 @@ pub struct Config {
     /// How many threads to use for running tests. Defaults to number of cores
     pub num_test_threads: NonZeroUsize,
     /// Where to dump files like the binaries compiled from tests.
-    pub out_dir: Option<PathBuf>,
+    /// Defaults to `target/ui` in the current directory.
+    pub out_dir: PathBuf,
     /// The default edition to use on all tests
     pub edition: Option<String>,
 }
@@ -113,7 +114,7 @@ impl Default for Config {
             dependency_builder: CommandBuilder::cargo(),
             quiet: false,
             num_test_threads: std::thread::available_parallelism().unwrap(),
-            out_dir: None,
+            out_dir: std::env::current_dir().unwrap().join("target/ui"),
             edition: Some("2021".into()),
         }
     }
@@ -212,6 +213,8 @@ pub struct CommandBuilder {
     pub program: PathBuf,
     /// Arguments to the binary.
     pub args: Vec<OsString>,
+    /// A flag to prefix before the path to where output files should be written.
+    pub out_dir_flag: Option<OsString>,
     /// Environment variables passed to the binary that is executed.
     /// The environment variable is removed if the second tuple field is `None`
     pub envs: Vec<(OsString, Option<OsString>)>,
@@ -223,6 +226,7 @@ impl CommandBuilder {
         Self {
             program: PathBuf::from(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into())),
             args: vec!["build".into()],
+            out_dir_flag: Some("--target-dir".into()),
             envs: vec![],
         }
     }
@@ -235,6 +239,7 @@ impl CommandBuilder {
         Self {
             program: PathBuf::from(std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into())),
             args: vec!["--error-format=json".into()],
+            out_dir_flag: Some("--out-dir".into()),
             envs: vec![],
         }
     }
@@ -253,6 +258,7 @@ impl CommandBuilder {
         Self {
             program: cmd.into(),
             args: vec![],
+            out_dir_flag: None,
             envs: vec![],
         }
     }
@@ -266,6 +272,9 @@ impl CommandBuilder {
                 for arg in &self.0.args {
                     write!(f, " {arg:?}")?;
                 }
+                if let Some(flag) = &self.0.out_dir_flag {
+                    write!(f, " {flag:?} OUT_DIR")?;
+                }
                 Ok(())
             }
         }
@@ -273,9 +282,12 @@ impl CommandBuilder {
     }
 
     /// Create a command with the given settings.
-    pub fn build(&self) -> Command {
+    pub fn build(&self, out_dir: &Path) -> Command {
         let mut cmd = Command::new(&self.program);
         cmd.args(self.args.iter());
+        if let Some(flag) = &self.out_dir_flag {
+            cmd.arg(flag).arg(out_dir);
+        }
         self.apply_env(&mut cmd);
         cmd
     }
@@ -714,11 +726,7 @@ fn build_command(
     comments: &Comments,
     errors: &mut Vec<Error>,
 ) -> Command {
-    let mut cmd = config.program.build();
-    if let Some(out_dir) = &config.out_dir {
-        cmd.arg("--out-dir");
-        cmd.arg(out_dir);
-    }
+    let mut cmd = config.program.build(&config.out_dir);
     cmd.arg(path);
     if !revision.is_empty() {
         cmd.arg(format!("--cfg={revision}"));
@@ -771,13 +779,7 @@ fn build_aux(
     // Put aux builds into a separate directory per test so that
     // tests running in parallel but building the same aux build don't conflict.
     // FIXME: put aux builds into the regular build queue.
-    config.out_dir = Some(
-        config
-            .out_dir
-            .clone()
-            .unwrap_or_default()
-            .join(path.with_extension("")),
-    );
+    config.out_dir = config.out_dir.clone().join(path.with_extension(""));
 
     let mut errors = vec![];
 
@@ -815,18 +817,15 @@ fn build_aux(
     let output = aux_cmd.output().unwrap();
     assert!(output.status.success());
 
-    // Unwrap is ok here, as we just filled the field with `Some`.
-    let out_dir = config.out_dir.unwrap();
-
     for file in output.stdout.lines() {
         let file = std::str::from_utf8(file).unwrap();
         let crate_name = filename.replace('-', "_");
-        let path = out_dir.join(file);
+        let path = config.out_dir.join(file);
         extra_args.push("--extern".into());
         extra_args.push(format!("{crate_name}={}", path.display()));
         // Help cargo find the crates added with `--extern`.
         extra_args.push("-L".into());
-        extra_args.push(out_dir.display().to_string());
+        extra_args.push(config.out_dir.display().to_string());
     }
     Ok(())
 }
@@ -967,7 +966,6 @@ fn run_test_binary(
     config: &Config,
     errors: &mut Vec<Error>,
 ) -> Command {
-    let out_dir = config.out_dir.as_deref();
     cmd.arg("--print").arg("file-names");
     let output = cmd.output().unwrap();
     assert!(output.status.success());
@@ -976,10 +974,7 @@ fn run_test_binary(
     let file = files.next().unwrap();
     assert_eq!(files.next(), None);
     let file = std::str::from_utf8(file).unwrap();
-    let exe = match out_dir {
-        None => PathBuf::from(file),
-        Some(path) => path.join(file),
-    };
+    let exe = config.out_dir.join(file);
     let mut exe = Command::new(exe);
     let output = exe.output().unwrap();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -70,7 +70,7 @@ fn run(name: &str, mode: Mode) -> Result<()> {
     config.stderr_filter("\\.exe", b"");
     config.stderr_filter(r#"(panic.*)\.rs:[0-9]+:[0-9]+"#, "$1.rs");
     config.stderr_filter("   [0-9]: .*", "");
-    config.stderr_filter("/target/[^/]+/debug", "/target/$$TRIPLE/debug");
+    config.stderr_filter("/target/[^/]+/[^/]+/debug", "/target/$$TMP/$$TRIPLE/debug");
     config.stderr_filter("(command: )\"[^<rp][^\"]+", "$1\"$$CMD");
 
     run_tests_generic(

--- a/tests/integrations/basic-bin/Cargo.lock
+++ b/tests/integrations/basic-bin/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
 name = "basic_bin"
 version = "0.1.0"
 dependencies = [
+ "tempfile",
  "ui_test",
 ]
 

--- a/tests/integrations/basic-bin/Cargo.toml
+++ b/tests/integrations/basic-bin/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dev-dependencies]
 ui_test = { path = "../../.."}
+tempfile = "3.3.0"
 
 [[test]]
 name = "ui_tests"

--- a/tests/integrations/basic-bin/tests/actual_tests/foomp.stderr
+++ b/tests/integrations/basic-bin/tests/actual_tests/foomp.stderr
@@ -1,4 +1,4 @@
-error: extern location for basic_bin is of an unknown type: $DIR/tests/integrations/basic-bin/../../../target/$TRIPLE/debug/basic_bin
+error: extern location for basic_bin is of an unknown type: $DIR/tests/integrations/basic-bin/../../../target/$TMP/$TRIPLE/debug/basic_bin
  --> $DIR/foomp.rs:1:5
   |
 1 | use basic_bin::add;

--- a/tests/integrations/basic-bin/tests/ui_tests.rs
+++ b/tests/integrations/basic-bin/tests/ui_tests.rs
@@ -11,16 +11,18 @@ fn main() -> ui_test::color_eyre::Result<()> {
     if std::env::var_os("BLESS").is_some() {
         config.output_conflict_handling = OutputConflictHandling::Bless
     }
-    config
-        .dependency_builder
-        .envs
-        .push(("CARGO_TARGET_DIR".into(), Some(path.into())));
     config.stderr_filter("in ([0-9]m )?[0-9\\.]+s", "");
     config.stdout_filter("in ([0-9]m )?[0-9\\.]+s", "");
     config.stderr_filter(r"[^ ]*/\.?cargo/registry/.*/", "$$CARGO_REGISTRY");
     config.stderr_filter(r"\.exe", "");
-    config.stderr_filter("/target/[^/]+/debug", "/target/$$TRIPLE/debug");
+    config.stderr_filter("/target/[^/]+/[^/]+/debug", "/target/$$TMP/$$TRIPLE/debug");
     config.path_stderr_filter(&std::path::Path::new(path), "$DIR");
+
+    // hide binaries generated for successfully passing tests
+    let tmp_dir = tempfile::tempdir_in(path)?;
+    let tmp_dir = tmp_dir.path();
+    config.out_dir = tmp_dir.into();
+    config.path_stderr_filter(tmp_dir, "$$TMP");
 
     run_tests_generic(
         config,

--- a/tests/integrations/basic-fail-mode/tests/run_file.rs
+++ b/tests/integrations/basic-fail-mode/tests/run_file.rs
@@ -6,8 +6,10 @@ use ui_test::*;
 fn run_file() -> Result<()> {
     let mut config = Config::default();
 
-    let tmp_dir = tempfile::tempdir()?;
-    config.out_dir = Some(tmp_dir.path().into());
+    let tmp_dir = tempfile::tempdir_in(env!("CARGO_TARGET_TMPDIR"))?;
+    let tmp_dir = tmp_dir.path();
+    config.out_dir = tmp_dir.into();
+    config.path_stderr_filter(tmp_dir, "$TMP");
 
     let mut result = ui_test::test_command(
         config,
@@ -43,16 +45,14 @@ fn run_file_no_deps() -> Result<()> {
 
     let mut config = Config::default();
 
-    let tmp_dir = tempfile::tempdir()?;
-    config.out_dir = Some(tmp_dir.path().into());
+    let tmp_dir = tempfile::tempdir_in(path)?;
+    let tmp_dir = tmp_dir.path();
+    config.out_dir = tmp_dir.into();
+    config.path_stderr_filter(tmp_dir, "$TMP");
 
     // Don't build a binary, we only provide .rmeta dependencies for now
     config.program.args.push("--emit=metadata".into());
     config.dependencies_crate_manifest_path = Some("Cargo.toml".into());
-    config
-        .dependency_builder
-        .envs
-        .push(("CARGO_TARGET_DIR".into(), Some(path.into())));
 
     let mut result = ui_test::test_command(
         config,

--- a/tests/integrations/basic-fail-mode/tests/ui_tests.rs
+++ b/tests/integrations/basic-fail-mode/tests/ui_tests.rs
@@ -14,10 +14,6 @@ fn main() -> ui_test::color_eyre::Result<()> {
     if std::env::var_os("BLESS").is_some() {
         config.output_conflict_handling = OutputConflictHandling::Bless
     }
-    config
-        .dependency_builder
-        .envs
-        .push(("CARGO_TARGET_DIR".into(), Some(path.into())));
     config.stderr_filter("in ([0-9]m )?[0-9\\.]+s", "");
     config.stdout_filter("in ([0-9]m )?[0-9\\.]+s", "");
     config.stderr_filter(r"[^ ]*/\.?cargo/registry/.*/", "$$CARGO_REGISTRY");

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -170,7 +170,7 @@ test result: FAIL. 6 tests failed, 0 tests passed, 0 ignored, 0 filtered out
 Error: tests failed
 
 Location:
-    $DIR/src/lib.rs:572:13
+    $DIR/src/lib.rs:565:13
 error: test failed, to rerun pass `--test ui_tests`
 
 Caused by:
@@ -491,7 +491,7 @@ test result: FAIL. 1 tests failed, 2 tests passed, 0 ignored, 0 filtered out
 thread 'main' panicked at 'invalid mode/result combo: yolo: Err(tests failed
 
 Location:
-    $DIR/src/lib.rs:572:13)', tests/ui_tests_bless.rs:54:18
+    $DIR/src/lib.rs:565:13)', tests/ui_tests_bless.rs:54:18
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: test failed, to rerun pass `--test ui_tests_bless`
 Error: failed to parse rustc version info: invalid_foobarlaksdfalsdfj
@@ -585,7 +585,7 @@ test result: FAIL. 6 tests failed, 0 tests passed, 0 ignored, 0 filtered out
 Error: tests failed
 
 Location:
-    $DIR/src/lib.rs:572:13
+    $DIR/src/lib.rs:565:13
 error: test failed, to rerun pass `--test ui_tests_invalid_program2`
 
 Caused by:

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -7,7 +7,7 @@ tests/actual_tests/filters.rs ... FAILED
 tests/actual_tests/foomp.rs ... FAILED
 
 tests/actual_tests/bad_pattern.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/bad_pattern.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/bad_pattern.rs" "--edition" "2021"
 
 substring `miesmätsched types` not found in stderr output
 expected because of pattern here: tests/actual_tests/bad_pattern.rs:5
@@ -53,7 +53,7 @@ full stderr:
 
 
 tests/actual_tests/executable_compile_err.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/executable_compile_err.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/executable_compile_err.rs" "--edition" "2021"
 
 run(0) test got exit status: 1, but expected 0
 
@@ -92,7 +92,7 @@ error: aborting due to previous error
 
 
 tests/actual_tests/exit_code_fail.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/exit_code_fail.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/exit_code_fail.rs" "--edition" "2021"
 
 fail test got exit status: 0, but expected 1
 
@@ -113,7 +113,7 @@ full stderr:
 
 
 tests/actual_tests/foomp.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/foomp.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/foomp.rs" "--edition" "2021"
 
 actual output differed from expected
 Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/foomp.stderr` to the actual output
@@ -170,7 +170,7 @@ test result: FAIL. 6 tests failed, 0 tests passed, 0 ignored, 0 filtered out
 Error: tests failed
 
 Location:
-    $DIR/src/lib.rs:565:13
+    $DIR/src/lib.rs:577:13
 error: test failed, to rerun pass `--test ui_tests`
 
 Caused by:
@@ -208,7 +208,7 @@ tests/actual_tests_bless/revisions_same_everywhere.rs (foo) ... ok
 tests/actual_tests_bless/revisions_same_everywhere.rs (bar) ... ok
 
 tests/actual_tests_bless/aux_proc_macro_misuse.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/auxiliary/the_proc_macro.rs" "--edition" "2021" "--crate-type" "lib" "--emit=link"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/auxiliary/the_proc_macro.rs" "--edition" "2021" "--crate-type" "lib" "--emit=link"
 
 Aux build from tests/actual_tests_bless/aux_proc_macro_misuse.rs:1 failed
 compilation of aux build failed failed with exit status: 1
@@ -258,7 +258,7 @@ full stderr:
 
 
 tests/actual_tests_bless/foomp-rustfix-fail-revisions.rs (revision `a`) FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/foomp-rustfix-fail-revisions.a.fixed" "--cfg=a" "--edition" "2021" "--crate-name" "foomp_rustfix_fail_revisions"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/foomp-rustfix-fail-revisions.a.fixed" "--cfg=a" "--edition" "2021" "--crate-name" "foomp_rustfix_fail_revisions"
 
 rustfix failed with exit status: 1
 
@@ -279,7 +279,7 @@ For more information about this error, try `rustc --explain E0308`.
 
 
 tests/actual_tests_bless/foomp-rustfix-fail-revisions.rs (revision `b`) FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/foomp-rustfix-fail-revisions.b.fixed" "--cfg=b" "--edition" "2021" "--crate-name" "foomp_rustfix_fail_revisions"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/foomp-rustfix-fail-revisions.b.fixed" "--cfg=b" "--edition" "2021" "--crate-name" "foomp_rustfix_fail_revisions"
 
 rustfix failed with exit status: 1
 
@@ -300,7 +300,7 @@ For more information about this error, try `rustc --explain E0308`.
 
 
 tests/actual_tests_bless/foomp-rustfix-fail.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/foomp-rustfix-fail.fixed" "--edition" "2021" "--crate-name" "foomp_rustfix_fail"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/foomp-rustfix-fail.fixed" "--edition" "2021" "--crate-name" "foomp_rustfix_fail"
 
 rustfix failed with exit status: 1
 
@@ -321,7 +321,7 @@ For more information about this error, try `rustc --explain E0308`.
 
 
 tests/actual_tests_bless/no_main.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--crate-type=lib" "--out-dir" "$TMP "tests/actual_tests_bless/no_main.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--crate-type=lib" "--out-dir" "$TMP "tests/actual_tests_bless/no_main.rs" "--edition" "2021"
 
 fail test got exit status: 0, but expected 1
 
@@ -332,7 +332,7 @@ full stderr:
 
 
 tests/actual_tests_bless/no_main_manual.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--crate-type=lib" "--out-dir" "$TMP "tests/actual_tests_bless/no_main_manual.rs" "--crate-type=bin" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--crate-type=lib" "--out-dir" "$TMP "tests/actual_tests_bless/no_main_manual.rs" "--crate-type=bin" "--edition" "2021"
 
 There were 1 unmatched diagnostics that occurred outside the testfile and had no pattern
     Error: cannot mix `bin` crate type with others
@@ -358,7 +358,7 @@ For more information about this error, try `rustc --explain E0601`.
 
 
 tests/actual_tests_bless/no_test.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--test" "--out-dir" "$TMP "tests/actual_tests_bless/no_test.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--test" "--out-dir" "$TMP "tests/actual_tests_bless/no_test.rs" "--edition" "2021"
 
 fail test got exit status: 0, but expected 1
 
@@ -396,7 +396,7 @@ full stderr:
 
 
 tests/actual_tests_bless/revisioned_executable.rs (revision `panic`) FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisioned_executable.rs" "--cfg=panic" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisioned_executable.rs" "--cfg=panic" "--edition" "2021"
 
 run(101) test got exit status: 0, but expected 101
 
@@ -414,7 +414,7 @@ full stderr:
 
 
 tests/actual_tests_bless/revisioned_executable_panic.rs (revision `panic`) FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisioned_executable_panic.rs" "--cfg=panic" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisioned_executable_panic.rs" "--cfg=panic" "--edition" "2021"
 
 run(101) test got exit status: 0, but expected 101
 
@@ -423,7 +423,7 @@ full stderr:
 
 
 tests/actual_tests_bless/revisions_bad.rs (revision `bar`) FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisions_bad.rs" "--cfg=bar" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisions_bad.rs" "--cfg=bar" "--edition" "2021"
 
 substring ``main` function not found in crate `revisions_bad`` not found in stderr output
 expected because of pattern here: tests/actual_tests_bless/revisions_bad.rs:4
@@ -467,7 +467,7 @@ tests/actual_tests_bless_yolo/revisions_bad.rs (foo) ... ok
 tests/actual_tests_bless_yolo/revisions_bad.rs (bar) ... FAILED
 
 tests/actual_tests_bless_yolo/revisions_bad.rs (revision `bar`) FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless_yolo/revisions_bad.rs" "--cfg=bar" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless_yolo/revisions_bad.rs" "--cfg=bar" "--edition" "2021"
 
 substring ``main` function not found in crate `revisions_bad`` not found in stderr output
 expected because of pattern here: tests/actual_tests_bless_yolo/revisions_bad.rs:4
@@ -491,7 +491,7 @@ test result: FAIL. 1 tests failed, 2 tests passed, 0 ignored, 0 filtered out
 thread 'main' panicked at 'invalid mode/result combo: yolo: Err(tests failed
 
 Location:
-    $DIR/src/lib.rs:565:13)', tests/ui_tests_bless.rs:54:18
+    $DIR/src/lib.rs:577:13)', tests/ui_tests_bless.rs:52:18
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: test failed, to rerun pass `--test ui_tests_bless`
 Error: failed to parse rustc version info: invalid_foobarlaksdfalsdfj
@@ -501,7 +501,7 @@ Caused by:
 
 
 Location:
-    $DIR/src/lib.rs:180:21
+    $DIR/src/lib.rs:181:21
 error: test failed, to rerun pass `--test ui_tests_invalid_program`
 
 Caused by:
@@ -585,7 +585,7 @@ test result: FAIL. 6 tests failed, 0 tests passed, 0 ignored, 0 filtered out
 Error: tests failed
 
 Location:
-    $DIR/src/lib.rs:565:13
+    $DIR/src/lib.rs:577:13
 error: test failed, to rerun pass `--test ui_tests_invalid_program2`
 
 Caused by:

--- a/tests/integrations/basic-fail/tests/ui_tests.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests.rs
@@ -15,14 +15,12 @@ fn main() -> ui_test::color_eyre::Result<()> {
         num_test_threads: NonZeroUsize::new(1).unwrap(),
         ..Config::default()
     };
-    config
-        .dependency_builder
-        .envs
-        .push(("CARGO_TARGET_DIR".into(), Some(path.into())));
 
     // hide binaries generated for successfully passing tests
-    let tmp_dir = tempfile::tempdir()?;
-    config.out_dir = Some(tmp_dir.path().into());
+    let tmp_dir = tempfile::tempdir_in(path)?;
+    let tmp_dir = tmp_dir.path();
+    config.out_dir = tmp_dir.into();
+    config.path_stderr_filter(tmp_dir, "$TMP");
 
     config.stderr_filter("in ([0-9]m )?[0-9\\.]+s", "");
     config.stdout_filter("in ([0-9]m )?[0-9\\.]+s", "");

--- a/tests/integrations/basic-fail/tests/ui_tests_bless.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_bless.rs
@@ -28,14 +28,12 @@ fn main() -> ui_test::color_eyre::Result<()> {
         if std::env::var_os("BLESS").is_some() {
             config.output_conflict_handling = OutputConflictHandling::Bless
         }
-        config
-            .dependency_builder
-            .envs
-            .push(("CARGO_TARGET_DIR".into(), Some(path.into())));
 
         // hide binaries generated for successfully passing tests
-        let tmp_dir = tempfile::tempdir()?;
-        config.out_dir = Some(tmp_dir.path().into());
+        let tmp_dir = tempfile::tempdir_in(path)?;
+        let tmp_dir = tmp_dir.path();
+        config.out_dir = tmp_dir.into();
+        config.path_stderr_filter(tmp_dir, "$TMP");
 
         config.stderr_filter("in ([0-9]m )?[0-9\\.]+s", "");
         config.stdout_filter("in ([0-9]m )?[0-9\\.]+s", "");

--- a/tests/integrations/basic/tests/run_file.rs
+++ b/tests/integrations/basic/tests/run_file.rs
@@ -6,8 +6,10 @@ use ui_test::*;
 fn run_file() -> Result<()> {
     let mut config = Config::default();
 
-    let tmp_dir = tempfile::tempdir()?;
-    config.out_dir = Some(tmp_dir.path().into());
+    let tmp_dir = tempfile::tempdir_in(env!("CARGO_TARGET_TMPDIR"))?;
+    let tmp_dir = tmp_dir.path();
+    config.out_dir = tmp_dir.into();
+    config.path_stderr_filter(tmp_dir, "$TMP");
 
     let mut result = ui_test::test_command(
         config,
@@ -26,16 +28,14 @@ fn run_file_with_deps() -> Result<()> {
 
     let mut config = Config::default();
 
-    let tmp_dir = tempfile::tempdir()?;
-    config.out_dir = Some(tmp_dir.path().into());
+    let tmp_dir = tempfile::tempdir_in(path)?;
+    let tmp_dir = tmp_dir.path();
+    config.out_dir = tmp_dir.into();
+    config.path_stderr_filter(tmp_dir, "$TMP");
 
     // Don't build a binary, we only provide .rmeta dependencies for now
     config.program.args.push("--emit=metadata".into());
     config.dependencies_crate_manifest_path = Some("Cargo.toml".into());
-    config
-        .dependency_builder
-        .envs
-        .push(("CARGO_TARGET_DIR".into(), Some(path.into())));
 
     let mut result = ui_test::test_command(
         config,

--- a/tests/integrations/basic/tests/ui_tests.rs
+++ b/tests/integrations/basic/tests/ui_tests.rs
@@ -13,18 +13,16 @@ fn main() -> ui_test::color_eyre::Result<()> {
     if std::env::var_os("BLESS").is_some() {
         config.output_conflict_handling = OutputConflictHandling::Bless;
     }
-    config
-        .dependency_builder
-        .envs
-        .push(("CARGO_TARGET_DIR".into(), Some(path.into())));
     config.stderr_filter("in ([0-9]m )?[0-9\\.]+s", "");
     config.stdout_filter("in ([0-9]m )?[0-9\\.]+s", "");
     config.stderr_filter(r"[^ ]*/\.?cargo/registry/.*/", "$$CARGO_REGISTRY");
     config.path_stderr_filter(&std::path::Path::new(path), "$DIR");
 
     // hide binaries generated for successfully passing tests
-    let tmp_dir = tempfile::tempdir()?;
-    config.out_dir = Some(tmp_dir.path().into());
+    let tmp_dir = tempfile::tempdir_in(path)?;
+    let tmp_dir = tmp_dir.path();
+    config.out_dir = tmp_dir.into();
+    config.path_stderr_filter(tmp_dir, "$TMP");
 
     run_tests_generic(
         config,


### PR DESCRIPTION
fixes #69

Each command can specify what flag it uses for setting a directory to dump build files. This means rustc can now use `--out-dir` and cargo can use `--target-dir`, removing the need for setting the `CARGO_TARGET_DIR` env variable