### PR TITLE
error when an error pattern comment refers to a line that doesn't exist

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -596,7 +596,12 @@ impl CommentParser<&mut Revisioned> {
             ),
             Some('^') => {
                 let offset = pattern.chars().take_while(|&c| c == '^').count();
-                (self.line - offset, &pattern[offset..])
+                if let Some(match_line) = self.line.checked_sub(offset) {
+                    (match_line, &pattern[offset..])
+                } else {
+                    self.error(format!("//~^ pattern is trying to refer to {} lines previous, but is only on line {}", offset, self.line));
+                    return;
+                }
             }
             Some(_) => (self.line, pattern),
             None => {

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -164,7 +164,7 @@ tests/actual_tests/pattern_too_many_arrow.rs FAILED:
 command: "parse comments"
 
 Could not parse comment in tests/actual_tests/pattern_too_many_arrow.rs:3 because
-//~^ pattern is trying to refer to 7 lines previous, but is only on line 3
+//~^ pattern is trying to refer to 7 lines above, but there are only 2 lines above
 
 full stderr:
 
@@ -637,7 +637,7 @@ tests/actual_tests/pattern_too_many_arrow.rs FAILED:
 command: "parse comments"
 
 Could not parse comment in tests/actual_tests/pattern_too_many_arrow.rs:3 because
-//~^ pattern is trying to refer to 7 lines previous, but is only on line 3
+//~^ pattern is trying to refer to 7 lines above, but there are only 2 lines above
 
 full stderr:
 

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -5,6 +5,7 @@ tests/actual_tests/executable_compile_err.rs ... FAILED
 tests/actual_tests/exit_code_fail.rs ... FAILED
 tests/actual_tests/filters.rs ... FAILED
 tests/actual_tests/foomp.rs ... FAILED
+tests/actual_tests/pattern_too_many_arrow.rs ... FAILED
 
 tests/actual_tests/bad_pattern.rs FAILED:
 command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/bad_pattern.rs" "--edition" "2021"
@@ -158,6 +159,16 @@ error: aborting due to previous error
 For more information about this error, try `rustc --explain E0308`.
 
 
+
+tests/actual_tests/pattern_too_many_arrow.rs FAILED:
+command: "parse comments"
+
+Could not parse comment in tests/actual_tests/pattern_too_many_arrow.rs:3 because
+//~^ pattern is trying to refer to 7 lines previous, but is only on line 3
+
+full stderr:
+
+
 FAILURES:
     tests/actual_tests/bad_pattern.rs
     tests/actual_tests/executable.rs
@@ -165,8 +176,9 @@ FAILURES:
     tests/actual_tests/exit_code_fail.rs
     tests/actual_tests/filters.rs
     tests/actual_tests/foomp.rs
+    tests/actual_tests/pattern_too_many_arrow.rs
 
-test result: FAIL. 6 tests failed, 0 tests passed, 0 ignored, 0 filtered out
+test result: FAIL. 7 tests failed, 0 tests passed, 0 ignored, 0 filtered out
 Error: tests failed
 
 Location:
@@ -564,6 +576,7 @@ tests/actual_tests/exit_code_fail.rs ... FAILED
 tests/actual_tests/filters.rs ... FAILED
 thread '<unnamed>' panicked at 'could not execute "invalid_foobarlaksdfalsdfj" "tests/actual_tests/foomp.rs" "--edition" "2021": No such file or directory', $DIR/src/lib.rs
 tests/actual_tests/foomp.rs ... FAILED
+tests/actual_tests/pattern_too_many_arrow.rs ... FAILED
 
 tests/actual_tests/bad_pattern.rs FAILED:
 command: "<unknown>"
@@ -619,6 +632,16 @@ A bug in `ui_test` occurred: could not execute "invalid_foobarlaksdfalsdfj" "tes
 full stderr:
 
 
+
+tests/actual_tests/pattern_too_many_arrow.rs FAILED:
+command: "parse comments"
+
+Could not parse comment in tests/actual_tests/pattern_too_many_arrow.rs:3 because
+//~^ pattern is trying to refer to 7 lines previous, but is only on line 3
+
+full stderr:
+
+
 FAILURES:
     tests/actual_tests/bad_pattern.rs
     tests/actual_tests/executable.rs
@@ -626,8 +649,9 @@ FAILURES:
     tests/actual_tests/exit_code_fail.rs
     tests/actual_tests/filters.rs
     tests/actual_tests/foomp.rs
+    tests/actual_tests/pattern_too_many_arrow.rs
 
-test result: FAIL. 6 tests failed, 0 tests passed, 0 ignored, 0 filtered out
+test result: FAIL. 7 tests failed, 0 tests passed, 0 ignored, 0 filtered out
 Error: tests failed
 
 Location:

--- a/tests/integrations/basic-fail/tests/actual_tests/pattern_too_many_arrow.rs
+++ b/tests/integrations/basic-fail/tests/actual_tests/pattern_too_many_arrow.rs
@@ -1,0 +1,6 @@
+fn main() {
+    use_unit(1_u32);
+    //~^^^^^^^ ERROR: mismatched types
+}
+
+fn use_unit(_: ()) {}


### PR DESCRIPTION
A `-` without checks meant that determining what line a `//~^` was pointing to could overflow. Emit an error since that's never a well formed comment.