### PR TITLE
Add a matcher for windows path backslashes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,8 +43,14 @@ jobs:
           - os: windows-latest
             host_target: i686-pc-windows-msvc
     runs-on: ${{ matrix.os }}
+    # Run tests under a directory with a space in it to double check the windows path heuristic
+    defaults:
+      run:
+        working-directory: "dir with spaces/ui test"
     steps:
     - uses: actions/checkout@v3
+      with:
+        path: "dir with spaces/ui test"
     - uses: dtolnay/rust-toolchain@stable
     - name: Build
       run: cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,7 @@ distance = "0.4.0"
 [dependencies.regex]
 version = "1.5.5"
 default-features = false
-# Features chosen to match those required by env_logger, to avoid rebuilds
-features = ["perf", "std"]
+features = ["perf", "std", "unicode-gencat"]
 
 [dependencies.color-eyre]
 version = "0.6.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,11 +17,12 @@ pub struct Config {
     /// `None` to run on the host, otherwise a target triple
     pub target: Option<String>,
     /// Filters applied to stderr output before processing it.
-    /// By default contains a filter for replacing backslashes with regular slashes.
-    /// On windows, contains a filter to replace `\n` with `\r\n`.
+    /// By default contains a filter for replacing backslashes in paths with
+    /// regular slashes.
+    /// On windows, contains a filter to remove `\r`.
     pub stderr_filters: Filter,
     /// Filters applied to stdout output before processing it.
-    /// On windows, contains a filter to replace `\n` with `\r\n`.
+    /// On windows, contains a filter to remove `\r`.
     pub stdout_filters: Filter,
     /// The folder in which to start searching for .rs files
     pub root_dir: PathBuf,
@@ -58,7 +59,7 @@ impl Config {
             host: None,
             target: None,
             stderr_filters: vec![
-                (Match::Exact(vec![b'\\']), b"/"),
+                (Match::PathBackslash, b"/"),
                 #[cfg(windows)]
                 (Match::Exact(vec![b'\r']), b""),
             ],

--- a/tests/integrations/basic/Cargo.stderr
+++ b/tests/integrations/basic/Cargo.stderr
@@ -5,7 +5,8 @@ tests/actual_tests/executable.rs ... ok
 tests/actual_tests/foomp-rustfix.rs ... ok
 tests/actual_tests/foomp.rs ... ok
 tests/actual_tests/unicode.rs ... ok
+tests/actual_tests/windows_paths.rs ... ok
 tests/actual_tests/subdir/aux_proc_macro.rs ... ok
 
-test result: ok. 7 tests passed, 0 ignored, 0 filtered out
+test result: ok. 8 tests passed, 0 ignored, 0 filtered out
 

--- a/tests/integrations/basic/tests/actual_tests/windows_paths.rs
+++ b/tests/integrations/basic/tests/actual_tests/windows_paths.rs
@@ -1,0 +1,25 @@
+fn main() {
+    let () = "escapes stay as backslashes: \t\r\n";
+    //~^ ERROR: mismatched types
+
+    let () = r"absolute: C:\foo\file.rs";
+    //~^ ERROR: mismatched types
+    let () = r"absolute, spaces: C:\foo bar\file.rs";
+    //~^ ERROR: mismatched types
+    let () = r"absolute, spaces, dir: C:\foo bar\some dir\";
+    //~^ ERROR: mismatched types
+    let () = r"absolute, spaces, no extension: C:\foo bar\some file";
+    //~^ ERROR: mismatched types
+
+    let () = r"relative: foo\file.rs";
+    //~^ ERROR: mismatched types
+
+    let () = r"unicode: Ryū\file.rs";
+    //~^ ERROR: mismatched types
+
+    let () = r"mixed seperators: C:\foo/../bar\";
+    //~^ ERROR: mismatched types
+
+    let () = r"unsupported: foo\bar";
+    //~^ ERROR: mismatched types
+}

--- a/tests/integrations/basic/tests/actual_tests/windows_paths.stderr
+++ b/tests/integrations/basic/tests/actual_tests/windows_paths.stderr
@@ -1,0 +1,75 @@
+error[E0308]: mismatched types
+ --> $DIR/windows_paths.rs:2:9
+  |
+2 |     let () = "escapes stay as backslashes: \t\r\n";
+  |         ^^   ------------------------------------- this expression has type `&str`
+  |         |
+  |         expected `str`, found `()`
+
+error[E0308]: mismatched types
+ --> $DIR/windows_paths.rs:5:9
+  |
+5 |     let () = r"absolute: C:/foo/file.rs";
+  |         ^^   --------------------------- this expression has type `&str`
+  |         |
+  |         expected `str`, found `()`
+
+error[E0308]: mismatched types
+ --> $DIR/windows_paths.rs:7:9
+  |
+7 |     let () = r"absolute, spaces: C:/foo bar/file.rs";
+  |         ^^   --------------------------------------- this expression has type `&str`
+  |         |
+  |         expected `str`, found `()`
+
+error[E0308]: mismatched types
+ --> $DIR/windows_paths.rs:9:9
+  |
+9 |     let () = r"absolute, spaces, dir: C:/foo bar/some dir/";
+  |         ^^   ---------------------------------------------- this expression has type `&str`
+  |         |
+  |         expected `str`, found `()`
+
+error[E0308]: mismatched types
+  --> $DIR/windows_paths.rs:11:9
+   |
+11 |     let () = r"absolute, spaces, no extension: C:/foo bar/some file";
+   |         ^^   ------------------------------------------------------- this expression has type `&str`
+   |         |
+   |         expected `str`, found `()`
+
+error[E0308]: mismatched types
+  --> $DIR/windows_paths.rs:14:9
+   |
+14 |     let () = r"relative: foo/file.rs";
+   |         ^^   ------------------------ this expression has type `&str`
+   |         |
+   |         expected `str`, found `()`
+
+error[E0308]: mismatched types
+  --> $DIR/windows_paths.rs:17:9
+   |
+17 |     let () = r"unicode: Ryū/file.rs";
+   |         ^^   ----------------------- this expression has type `&str`
+   |         |
+   |         expected `str`, found `()`
+
+error[E0308]: mismatched types
+  --> $DIR/windows_paths.rs:20:9
+   |
+20 |     let () = r"mixed seperators: C:/foo/../bar/";
+   |         ^^   ----------------------------------- this expression has type `&str`
+   |         |
+   |         expected `str`, found `()`
+
+error[E0308]: mismatched types
+  --> $DIR/windows_paths.rs:23:9
+   |
+23 |     let () = r"unsupported: foo\bar";
+   |         ^^   ----------------------- this expression has type `&str`
+   |         |
+   |         expected `str`, found `()`
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #89

Slightly different than [the rustc one](https://github.com/rust-lang/rust/blob/6ce22733b973355573efd1e6294e585460e90e17/src/tools/compiletest/src/runtest.rs#L3748-L3775), it assumes it will be ran against generally unsubstituted paths (no `$DIR\foo\...`) because `Config::path_stderr_filter` switches the `\`s in windows paths to `/`

It does require an extra feature enabled on `regex` for the unicode property escapes