### PR TITLE
Automatically detect aux builds that are proc macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ their command specifies, or the test will fail without even being run.
 * `//@check-pass` overrides the `Config::mode` and will make the test behave as if the test suite were in `Mode::Pass`.
 * `//@edition: EDITION` overwrites the default edition (2021) to the given edition.
 * `//@no-rustfix` do not run [rustfix] on tests that have machine applicable suggestions.
-* `//@aux-build: filename` looks for a file in the `auxiliary` directory (within the directory of the test), compiles it as a library and links the current crate against it. This allows you import the crate with `extern crate` or just via `use` statements.
-    * you can optionally specify a crate type via `//@aux-build: filename.rs:proc-macro`. This is necessary for some crates (like proc macros), but can also be used to change the linkage against the aux build.
+* `//@aux-build: filename` looks for a file in the `auxiliary` directory (within the directory of the test), compiles it as a library and links the current crate against it. This allows you import the crate with `extern crate` or just via `use` statements. This will automatically detect aux files that are proc macros and build them as proc macros.
 * `//@run` compiles the test and runs the resulting binary. The resulting binary must exit successfully. Stdout and stderr are taken from the resulting binary. Any warnings during compilation are ignored.
     * You can also specify a different exit code/status that is expected via e.g. `//@run: 1` or `//@run: 101` (the latter is the standard Rust exit code for panics).
 
@@ -62,5 +61,4 @@ their command specifies, or the test will fail without even being run.
 * `ignore-target-*` and `only-target-*` operate solely on the triple, instead of supporting things like `macos`
 * only supports `ui` tests
 * tests are run in named order, so you can prefix slow tests with `0` in order to make them get run first
-* `aux-build`s for proc macros require an additional `:proc-macro` after the file name, but then the aux file itself needs no `#![proc_macro]` or other flags.
 * `aux-build`s require specifying nested aux builds explicitly and will not allow you to reference sibling `aux-build`s' artifacts.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -108,7 +108,7 @@ pub(crate) struct Revisioned {
     /// Ignore diagnostics below this level.
     /// `None` means pick the lowest level from the `error_pattern`s.
     pub require_annotations_for_level: OptWithLine<Level>,
-    pub aux_builds: Vec<WithLine<(PathBuf, String)>>,
+    pub aux_builds: Vec<WithLine<PathBuf>>,
     pub edition: OptWithLine<String>,
     /// Overwrites the mode from `Config`.
     pub mode: OptWithLine<Mode>,
@@ -490,9 +490,15 @@ impl CommentParser<&mut Revisioned> {
                 this.needs_asm_support = true;
             }
             "aux-build" => (this, args){
-                let (name, kind) = args.split_once(':').unwrap_or((args, "lib"));
+                let name = match args.split_once(':') {
+                    Some((name, _)) => {
+                        this.error("proc macros are now auto-detected, you can remove the `:proc-macro` after the file name");
+                        name
+                    },
+                    None => args,
+                };
                 let line = this.line;
-                this.aux_builds.push(WithLine::new((name.into(), kind.into()), line));
+                this.aux_builds.push(WithLine::new(name.into(), line));
             }
             "edition" => (this, args){
                 let line = this.line;

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -232,21 +232,12 @@ tests/actual_tests_bless/unknown_revision.rs ... FAILED
 tests/actual_tests_bless/unknown_revision2.rs ... FAILED
 
 tests/actual_tests_bless/aux_proc_macro_misuse.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/auxiliary/the_proc_macro.rs" "--edition" "2021" "--crate-type" "lib" "--emit=link"
+command: "parse comments"
 
-Aux build from tests/actual_tests_bless/aux_proc_macro_misuse.rs:1 failed
-compilation of aux build failed failed with exit status: 1
-
+Could not parse comment in tests/actual_tests_bless/aux_proc_macro_misuse.rs:1 because
+proc macros are now auto-detected, you can remove the `:proc-macro` after the file name
 
 full stderr:
-error: the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
- --> tests/actual_tests_bless/auxiliary/the_proc_macro.rs:7:1
-  |
-7 | #[proc_macro]
-  | ^^^^^^^^^^^^^
-
-error: aborting due to previous error
-
 
 
 

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/aux_proc_macro_misuse.rs
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/aux_proc_macro_misuse.rs
@@ -1,4 +1,4 @@
-//@aux-build:the_proc_macro.rs
+//@aux-build:the_proc_macro.rs:proc-macro
 
 use the_proc_macro::thing;
 

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/aux_proc_macro_no_main.rs
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/aux_proc_macro_no_main.rs
@@ -1,4 +1,4 @@
-//@aux-build:the_proc_macro.rs:proc-macro
+//@aux-build:the_proc_macro.rs
 //! Test that our automatic --crate-type detection (changing this crate to `lib`)
 //! does not change the aux build to `lib`
 

--- a/tests/integrations/basic/tests/actual_tests/aux_derive.fixed
+++ b/tests/integrations/basic/tests/actual_tests/aux_derive.fixed
@@ -1,4 +1,4 @@
-//@aux-build:derive_proc_macro.rs:proc-macro
+//@aux-build:derive_proc_macro.rs
 
 #[macro_use]
 extern crate derive_proc_macro;

--- a/tests/integrations/basic/tests/actual_tests/aux_derive.rs
+++ b/tests/integrations/basic/tests/actual_tests/aux_derive.rs
@@ -1,4 +1,4 @@
-//@aux-build:derive_proc_macro.rs:proc-macro
+//@aux-build:derive_proc_macro.rs
 
 #[macro_use]
 extern crate derive_proc_macro;

--- a/tests/integrations/basic/tests/actual_tests/aux_proc_macro.rs
+++ b/tests/integrations/basic/tests/actual_tests/aux_proc_macro.rs
@@ -1,4 +1,4 @@
-//@aux-build:the_proc_macro.rs:proc-macro
+//@aux-build:the_proc_macro.rs
 
 use the_proc_macro::thing;
 

--- a/tests/integrations/basic/tests/actual_tests/subdir/aux_proc_macro.rs
+++ b/tests/integrations/basic/tests/actual_tests/subdir/aux_proc_macro.rs
@@ -1,4 +1,4 @@
-//@aux-build:../auxiliary/the_proc_macro.rs:proc-macro
+//@aux-build:../auxiliary/the_proc_macro.rs
 
 use the_proc_macro::thing;
 


### PR DESCRIPTION
now that we have auto-detection for tests being binaries, tests, libraries or proc macros, use that logic for aux builds, too.