### PR TITLE
Show the status of long running tests by adding their last output line to the spinner.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ use color_eyre::eyre::{eyre, Result};
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use lazy_static::lazy_static;
 use parser::{ErrorMatch, MaybeWithLine, OptWithLine, Revisioned, WithLine};
+use read_helper::ReadHelper;
 use regex::bytes::{Captures, Regex};
 use rustc_stderr::{Level, Message};
 use status_emitter::{StatusEmitter, TestStatus};
@@ -23,8 +24,9 @@ use std::borrow::Cow;
 use std::collections::{HashSet, VecDeque};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, ExitStatus, Stdio};
 use std::thread;
+use std::time::Duration;
 
 use crate::parser::{Comments, Condition};
 
@@ -36,6 +38,7 @@ mod error;
 pub mod github_actions;
 mod mode;
 mod parser;
+mod read_helper;
 mod rustc_stderr;
 pub mod status_emitter;
 #[cfg(test)]
@@ -547,20 +550,19 @@ impl dyn TestStatus {
         let mut cmd = build_command(path, config, revision, comments)?;
         cmd.args(&extra_args);
 
-        let output = cmd
-            .output()
-            .unwrap_or_else(|err| panic!("could not execute {cmd:?}: {err}"));
+        let (status, stderr, stdout) = self.run_command(&mut cmd);
+
         let mode = config.mode.maybe_override(comments, revision)?;
 
         match *mode {
-            Mode::Run { .. } if Mode::Pass.ok(output.status).is_ok() => {
+            Mode::Run { .. } if Mode::Pass.ok(status).is_ok() => {
                 return run_test_binary(mode, path, revision, comments, cmd, config)
             }
             Mode::Panic | Mode::Yolo => {}
             Mode::Run { .. } | Mode::Pass | Mode::Fail { .. } => {
-                if output.status.code() == Some(101) {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    let stdout = String::from_utf8_lossy(&output.stdout);
+                if status.code() == Some(101) {
+                    let stderr = String::from_utf8_lossy(&stderr);
+                    let stdout = String::from_utf8_lossy(&stdout);
                     return Err(Errored {
                         command: cmd,
                         errors: vec![Error::Bug(format!(
@@ -571,9 +573,48 @@ impl dyn TestStatus {
                 }
             }
         }
-        check_test_result(cmd, *mode, path, config, revision, comments, &output)?;
-        run_rustfix(&output.stderr, path, comments, revision, config, extra_args)?;
+        check_test_result(
+            cmd, *mode, path, config, revision, comments, status, stdout, &stderr,
+        )?;
+        run_rustfix(&stderr, path, comments, revision, config, extra_args)?;
         Ok(TestOk::Ok)
+    }
+
+    /// Run a command, and if it takes more than 100ms, start appending the last stderr/stdout
+    /// line to the current status spinner.
+    fn run_command(&self, cmd: &mut Command) -> (ExitStatus, Vec<u8>, Vec<u8>) {
+        let mut child = cmd
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stdin(Stdio::null())
+            .spawn()
+            .unwrap_or_else(|err| panic!("could not execute {cmd:?}: {err}"));
+
+        let mut stdout = ReadHelper::from(child.stdout.take().unwrap());
+        let mut stderr = ReadHelper::from(child.stderr.take().unwrap());
+
+        let start = std::time::Instant::now();
+        let status = loop {
+            if let Some(exit) = child.try_wait().unwrap() {
+                break exit;
+            }
+            if start.elapsed() < Duration::from_millis(100) {
+                std::thread::sleep(Duration::from_millis(5));
+                continue;
+            }
+
+            let status = stderr.last_line();
+            if status.is_empty() {
+                let status = stdout.last_line();
+                if !status.is_empty() {
+                    self.update_status(status.to_str_lossy().to_string())
+                }
+            } else {
+                self.update_status(status.to_str_lossy().to_string())
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        };
+        (status, stderr.read_to_end(), stdout.read_to_end())
     }
 }
 
@@ -816,19 +857,21 @@ fn check_test_result(
     config: &Config,
     revision: &str,
     comments: &Comments,
-    output: &Output,
+    status: ExitStatus,
+    stdout: Vec<u8>,
+    stderr: &[u8],
 ) -> Result<(), Errored> {
     let mut errors = vec![];
-    errors.extend(mode.ok(output.status).err());
+    errors.extend(mode.ok(status).err());
     // Always remove annotation comments from stderr.
-    let diagnostics = rustc_stderr::process(path, &output.stderr);
+    let diagnostics = rustc_stderr::process(path, stderr);
     check_test_output(
         path,
         &mut errors,
         revision,
         config,
         comments,
-        &output.stdout,
+        &stdout,
         &diagnostics.rendered,
     );
     // Check error annotations in the source against output

--- a/src/read_helper.rs
+++ b/src/read_helper.rs
@@ -1,0 +1,43 @@
+use bstr::ByteSlice;
+use std::io::Read;
+
+pub struct ReadHelper<T> {
+    read: T,
+    buf: Vec<u8>,
+}
+
+impl<T> From<T> for ReadHelper<T> {
+    fn from(read: T) -> Self {
+        Self { read, buf: vec![] }
+    }
+}
+
+impl<T> Drop for ReadHelper<T> {
+    fn drop(&mut self) {
+        panic!("you need to `read_to_end` a `ReadHelper`")
+    }
+}
+
+impl<T: Read> ReadHelper<T> {
+    pub fn last_line(&mut self) -> &[u8] {
+        let mut buf = [0; 100];
+        while let Ok(n @ 1..) = self.read.read(&mut buf) {
+            self.buf.extend(&buf[..n]);
+            if n != 100 {
+                break;
+            }
+        }
+
+        self.buf
+            .lines()
+            .rev()
+            .find(|line| line.is_empty() || line.chars().all(|c| c.is_whitespace()))
+            .unwrap_or(&[])
+    }
+    pub fn read_to_end(mut self) -> Vec<u8> {
+        self.read.read_to_end(&mut self.buf).unwrap();
+        let buf = std::mem::take(&mut self.buf);
+        std::mem::forget(self);
+        buf
+    }
+}


### PR DESCRIPTION
This is mainly useful for the dogfood test in this repo, but I assume other test suites will have long running tests, too.

Locally this allows me to see which test is currently running, and it at least provides some sort of progress information by changing what is displayed.