### PR TITLE
Actually make the status work.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -590,7 +590,7 @@ impl dyn TestStatus {
             .spawn()
             .unwrap_or_else(|err| panic!("could not execute {cmd:?}: {err}"));
 
-        let mut stdout = ReadHelper::from(child.stdout.take().unwrap());
+        let stdout = ReadHelper::from(child.stdout.take().unwrap());
         let mut stderr = ReadHelper::from(child.stderr.take().unwrap());
 
         let start = std::time::Instant::now();
@@ -604,12 +604,7 @@ impl dyn TestStatus {
             }
 
             let status = stderr.last_line();
-            if status.is_empty() {
-                let status = stdout.last_line();
-                if !status.is_empty() {
-                    self.update_status(status.to_str_lossy().to_string())
-                }
-            } else {
+            if !status.is_empty() {
                 self.update_status(status.to_str_lossy().to_string())
             }
             std::thread::sleep(Duration::from_millis(100));

--- a/src/read_helper.rs
+++ b/src/read_helper.rs
@@ -31,7 +31,7 @@ impl<T: Read> ReadHelper<T> {
         self.buf
             .lines()
             .rev()
-            .find(|line| line.is_empty() || line.chars().all(|c| c.is_whitespace()))
+            .find(|line| !line.is_empty() && line.chars().any(|c| !c.is_whitespace()))
             .unwrap_or(&[])
     }
     pub fn read_to_end(mut self) -> Vec<u8> {


### PR DESCRIPTION
Don't wait on stdout, it will block until output happens, and then we don't see any stderr.

I mis-followed a clippy lint in https://github.com/oli-obk/ui_test/pull/119 and thus only showed the lines that were empty instead of the lines that had content