### PR TITLE
Build aux builds only once

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -140,24 +140,25 @@ impl Config {
             .push((Regex::new(pattern).unwrap().into(), replacement.as_ref()));
     }
 
-    /// Compile dependencies and make sure `Config::program` contains the right flags
+    /// Compile dependencies and return the right flags
     /// to find the dependencies.
-    pub fn build_dependencies_and_link_them(&mut self) -> Result<()> {
+    pub fn build_dependencies(&self) -> Result<Vec<OsString>> {
         let dependencies = build_dependencies(self)?;
+        let mut args = vec![];
         for (name, artifacts) in dependencies.dependencies {
             for dependency in artifacts {
-                self.program.args.push("--extern".into());
+                args.push("--extern".into());
                 let mut dep = OsString::from(&name);
                 dep.push("=");
                 dep.push(dependency);
-                self.program.args.push(dep);
+                args.push(dep);
             }
         }
         for import_path in dependencies.import_paths {
-            self.program.args.push("-L".into());
-            self.program.args.push(import_path.into());
+            args.push("-L".into());
+            args.push(import_path.into());
         }
-        Ok(())
+        Ok(args)
     }
 
     /// Make sure we have the host and target triples.

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,9 +31,6 @@ pub struct Config {
     pub root_dir: PathBuf,
     /// The mode in which to run the tests.
     pub mode: Mode,
-    /// Run [`rustfix`] on tests that produce machine applicable (or any
-    /// with [`Mode::Yolo`]) suggestions
-    pub rustfix: bool,
     /// The binary to actually execute.
     pub program: CommandBuilder,
     /// The command to run to obtain the cfgs that the output is supposed to
@@ -76,8 +73,8 @@ impl Config {
             root_dir: root_dir.into(),
             mode: Mode::Fail {
                 require_patterns: true,
+                rustfix: true,
             },
-            rustfix: true,
             program: CommandBuilder::rustc(),
             cfgs: CommandBuilder::cfgs(),
             output_conflict_handling: OutputConflictHandling::Error(format!(
@@ -104,7 +101,10 @@ impl Config {
         Self {
             program: CommandBuilder::cargo(),
             edition: None,
-            rustfix: false,
+            mode: Mode::Fail {
+                require_patterns: true,
+                rustfix: false,
+            },
             ..Self::rustc(root_dir)
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,8 @@ impl Config {
                 (Match::PathBackslash, b"/"),
                 #[cfg(windows)]
                 (Match::Exact(vec![b'\r']), b""),
+                #[cfg(windows)]
+                (Match::Exact(br"\\?\".to_vec()), b""),
             ],
             stdout_filters: vec![
                 #[cfg(windows)]

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -84,7 +84,7 @@ pub(crate) fn build_dependencies(config: &Config) -> Result<Dependencies> {
     let mut artifacts = HashMap::new();
     for line in artifact_output.lines() {
         let Ok(message) = serde_json::from_str::<cargo_metadata::Message>(line) else {
-            continue
+            continue;
         };
         if let cargo_metadata::Message::CompilerArtifact(artifact) = message {
             if artifact

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -41,13 +41,12 @@ fn cfgs(config: &Config) -> Result<Vec<Cfg>> {
 }
 
 /// Compiles dependencies and returns the crate names and corresponding rmeta files.
-pub fn build_dependencies(config: &mut Config) -> Result<Dependencies> {
+pub(crate) fn build_dependencies(config: &Config) -> Result<Dependencies> {
     let manifest_path = match &config.dependencies_crate_manifest_path {
         Some(path) => path.to_owned(),
         None => return Ok(Default::default()),
     };
     let manifest_path = &manifest_path;
-    config.fill_host_and_target()?;
     eprintln!("   Building test dependencies...");
     let mut build = config.dependency_builder.build(&config.out_dir);
     build.arg(manifest_path);

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -199,7 +199,7 @@ pub enum Build {
     /// Build the dependencies.
     Dependencies,
     /// Build an aux-build.
-    Aux { aux_file: PathBuf, aux: PathBuf },
+    Aux { aux_file: PathBuf },
 }
 
 #[derive(Default)]
@@ -255,7 +255,7 @@ impl BuildManager {
                     Err(())
                 }
             },
-            Build::Aux { aux_file, aux } => match build_aux(aux_file, config, aux, self) {
+            Build::Aux { aux_file } => match build_aux(aux_file, config, self) {
                 Ok(args) => Ok(args.iter().map(Into::into).collect()),
                 Err(e) => {
                     err = Some(e);

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -58,7 +58,7 @@ pub fn build_dependencies(config: &mut Config) -> Result<Dependencies> {
 
     // Reusable closure for setting up the environment both for artifact generation and `cargo_metadata`
     let set_locking = |cmd: &mut Command| match (&config.output_conflict_handling, &config.mode) {
-        (_, Mode::Yolo) => {}
+        (_, Mode::Yolo { .. }) => {}
         (OutputConflictHandling::Error(_), _) => {
             cmd.arg("--locked");
         }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -54,7 +54,9 @@ fn row(row: DiffOp<&str>) {
 fn print_line_diff(l: &str, r: &str) {
     let diff = diff_words(l, r);
     let diff = diff.diff();
-    if has_both_insertions_and_deletions(&diff) {
+    if has_both_insertions_and_deletions(&diff)
+        || !colored::control::SHOULD_COLORIZE.should_colorize()
+    {
         // The line both adds and removes chars, print both lines, but highlight their differences instead of
         // drawing the entire line in red/green.
         eprint!("{}", "-".red());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,7 @@ pub fn default_per_file_config(config: &Config, path: &Path) -> Option<Config> {
 /// Create a command for running a single file, with the settings from the `config` argument.
 /// Ignores various settings from `Config` that relate to finding test files.
 pub fn test_command(mut config: Config, path: &Path) -> Result<Command> {
+    config.fill_host_and_target()?;
     config.build_dependencies_and_link_them()?;
 
     let comments =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -539,6 +539,7 @@ impl dyn TestStatus {
     fn run_test(&self, config: &Config, comments: &Comments) -> TestResult {
         let path = self.path();
         let revision = self.revision();
+        // FIXME: block test runs until their aux files are built and share aux builds between tests.
         let extra_args = build_aux_files(
             path,
             &path.parent().unwrap().join("auxiliary"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -547,13 +547,7 @@ impl dyn TestStatus {
         config: &Config,
         comments: &Comments,
     ) -> TestResult {
-        let extra_args = build_manager
-            .build(Build::Dependencies, config)
-            .map_err(|err| Errored {
-                command: Command::new("building dependencies"),
-                errors: vec![],
-                stderr: format!("{err:?}").into_bytes(),
-            })?;
+        let extra_args = build_manager.build(Build::Dependencies, config)?;
         let mut config = config.clone();
         config.program.args.extend(extra_args);
         let config = &config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -655,7 +655,7 @@ fn build_aux_files(
                 build_manager
                     .build(
                         Build::Aux {
-                            aux_file: aux_file.clone(),
+                            aux_file: aux_file.canonicalize().unwrap(),
                         },
                         config,
                     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,7 +495,19 @@ fn build_aux(
         }
     });
 
-    let config = default_per_file_config(&config, aux_file).unwrap();
+    let mut config = default_per_file_config(&config, aux_file).unwrap();
+    let mut components = aux_file.parent().unwrap().components();
+
+    // Put aux builds into a separate directory per path so that multiple aux files
+    // from different directories (but with the same file name) don't collide.
+    for c in config.out_dir.components() {
+        let c2 = components.next();
+        if Some(c) != c2 {
+            config.out_dir.extend(c2);
+            config.out_dir.extend(components);
+            break;
+        }
+    }
 
     let mut aux_cmd = build_command(aux_file, &config, "", &comments)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,7 +465,6 @@ fn build_command(
 fn build_aux(
     aux_file: &Path,
     config: &Config,
-    aux: &Path,
     build_manager: &BuildManager,
 ) -> std::result::Result<Vec<OsString>, Errored> {
     let comments = parse_comments_in_file(aux_file)?;
@@ -511,7 +510,7 @@ fn build_aux(
     aux_cmd.args(extra_args.iter());
 
     aux_cmd.arg("--emit=link");
-    let filename = aux.file_stem().unwrap().to_str().unwrap();
+    let filename = aux_file.file_stem().unwrap().to_str().unwrap();
     let output = aux_cmd.output().unwrap();
     if !output.status.success() {
         let error = Error::Command {
@@ -657,7 +656,6 @@ fn build_aux_files(
                     .build(
                         Build::Aux {
                             aux_file: aux_file.clone(),
-                            aux: aux.clone(),
                         },
                         config,
                     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use std::borrow::Cow;
 use std::collections::{HashSet, VecDeque};
 use std::ffi::OsString;
 use std::num::NonZeroUsize;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf, Prefix};
 use std::process::{Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::Duration;
@@ -501,8 +501,16 @@ fn build_aux(
     // Put aux builds into a separate directory per path so that multiple aux files
     // from different directories (but with the same file name) don't collide.
     for c in config.out_dir.components() {
+        let deverbatimize = |c| match c {
+            Component::Prefix(prefix) => Err(match prefix.kind() {
+                Prefix::VerbatimUNC(a, b) => Prefix::UNC(a, b),
+                Prefix::VerbatimDisk(d) => Prefix::Disk(d),
+                other => other,
+            }),
+            c => Ok(c),
+        };
         let c2 = components.next();
-        if Some(c) != c2 {
+        if Some(deverbatimize(c)) != c2.map(deverbatimize) {
             config.out_dir.extend(c2);
             config.out_dir.extend(components);
             break;

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -21,9 +21,14 @@ pub enum Mode {
     Fail {
         /// Whether failing tests must have error patterns. Set to false if you just care about .stderr output.
         require_patterns: bool,
+        /// Whether to run rustfix on the test if it has machine applicable suggestions.
+        rustfix: bool,
     },
     /// Run the tests, but always pass them as long as all annotations are satisfied and stderr files match.
-    Yolo,
+    Yolo {
+        /// Whether to run
+        rustfix: bool,
+    },
 }
 
 impl Mode {
@@ -33,7 +38,7 @@ impl Mode {
             Mode::Pass => 0,
             Mode::Panic => 101,
             Mode::Fail { .. } => 1,
-            Mode::Yolo => return Ok(()),
+            Mode::Yolo { .. } => return Ok(()),
         };
         if status.code() == Some(expected) {
             Ok(())
@@ -63,8 +68,9 @@ impl Display for Mode {
             Mode::Panic => write!(f, "panic"),
             Mode::Fail {
                 require_patterns: _,
+                rustfix: _,
             } => write!(f, "fail"),
-            Mode::Yolo => write!(f, "yolo"),
+            Mode::Yolo { rustfix: _ } => write!(f, "yolo"),
         }
     }
 }

--- a/src/status_emitter.rs
+++ b/src/status_emitter.rs
@@ -195,6 +195,7 @@ impl TestStatus for TextTest {
             let msg = format!("{old_msg} ... {result}");
             if ProgressDrawTarget::stderr().is_hidden() {
                 eprintln!("{msg}");
+                std::io::stderr().flush().unwrap();
             } else {
                 self.text.sender.send(Msg::Pop(old_msg, Some(msg))).unwrap();
             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -72,7 +72,6 @@ fn run(name: &str, mode: Mode) -> Result<()> {
     config.stderr_filter("/target/.tmp[^/ \"]+", "/target/$$TMP");
     // Normalize proc macro filenames on windows to their linux repr
     config.stderr_filter("/([^/\\.]+)\\.dll", "/lib$1.so");
-    config.stderr_filter(r"\\\?\\", "");
     // Normalize proc macro filenames on mac to their linux repr
     config.stderr_filter("/([^/\\.]+)\\.dylib", "/$1.so");
     config.stderr_filter("(command: )\"[^<rp][^\"]+", "$1\"$$CMD");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -109,7 +109,7 @@ fn run(name: &str, mode: Mode) -> Result<()> {
                     // multiple [[test]]s exist. If there's only one test, it returns
                     // 1 on failure.
                     Mode::Panic => fail,
-                    Mode::Run { .. } | Mode::Yolo | Mode::Fail { .. } => unreachable!(),
+                    Mode::Run { .. } | Mode::Yolo { .. } | Mode::Fail { .. } => unreachable!(),
                 }
                 && default_filter_by_arg(path, args)
         },

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -79,6 +79,9 @@ fn run(name: &str, mode: Mode) -> Result<()> {
     config.stderr_filter("(src/.*?\\.rs):[0-9]+:[0-9]+", "$1:LL:CC");
     config.stderr_filter("program not found", "No such file or directory");
     config.stderr_filter(" \\(os error [0-9]+\\)", "");
+    // We emit this message on a thread, so it can sometimes happen that it
+    // appears earlier or later than the regular test messages.
+    config.stderr_filter("   Building test dependencies...\n", "");
 
     let text = if args.quiet {
         ui_test::status_emitter::Text::quiet()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -72,6 +72,7 @@ fn run(name: &str, mode: Mode) -> Result<()> {
     config.stderr_filter("/target/.tmp[^/ \"]+", "/target/$$TMP");
     // Normalize proc macro filenames on windows to their linux repr
     config.stderr_filter("/([^/\\.]+)\\.dll", "/lib$1.so");
+    config.stderr_filter(r"\\\?\\", "");
     // Normalize proc macro filenames on mac to their linux repr
     config.stderr_filter("/([^/\\.]+)\\.dylib", "/$1.so");
     config.stderr_filter("(command: )\"[^<rp][^\"]+", "$1\"$$CMD");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -69,7 +69,7 @@ fn run(name: &str, mode: Mode) -> Result<()> {
     config.stderr_filter(r#"(panic.*)\.rs:[0-9]+:[0-9]+"#, "$1.rs");
     config.stderr_filter("   [0-9]: .*", "");
     config.stderr_filter("/target/[^/]+/[^/]+/debug", "/target/$$TMP/$$TRIPLE/debug");
-    config.stderr_filter("/target/[^/]+/tests", "/target/$$TMP/tests");
+    config.stderr_filter("/target/.tmp[^/ \"]+", "/target/$$TMP");
     // Normalize proc macro filenames on windows to their linux repr
     config.stderr_filter("/([^/\\.]+)\\.dll", "/lib$1.so");
     // Normalize proc macro filenames on mac to their linux repr

--- a/tests/integrations/basic-bin/Cargo.stderr
+++ b/tests/integrations/basic-bin/Cargo.stderr
@@ -1,4 +1,3 @@
-   Building test dependencies...
 tests/actual_tests/foomp.rs ... ok
 
 test result: ok. 1 tests passed, 0 ignored, 0 filtered out

--- a/tests/integrations/basic-fail-mode/Cargo.stderr
+++ b/tests/integrations/basic-fail-mode/Cargo.stderr
@@ -1,4 +1,3 @@
-   Building test dependencies...
 tests/actual_tests/foomp.rs ... ok
 
 test result: ok. 1 tests passed, 0 ignored, 0 filtered out

--- a/tests/integrations/basic-fail-mode/tests/run_file.rs
+++ b/tests/integrations/basic-fail-mode/tests/run_file.rs
@@ -25,6 +25,7 @@ fn run_file() -> Result<()> {
 #[test]
 fn fail_run_file() {
     let mut config = Config::rustc(PathBuf::new());
+    config.host = Some(String::new());
     config.program = CommandBuilder::cmd("invalid_alsdkfjalsdfjalskdfj");
 
     let _ = ui_test::test_command(

--- a/tests/integrations/basic-fail-mode/tests/ui_tests.rs
+++ b/tests/integrations/basic-fail-mode/tests/ui_tests.rs
@@ -6,6 +6,7 @@ fn main() -> ui_test::color_eyre::Result<()> {
         dependencies_crate_manifest_path: Some("Cargo.toml".into()),
         mode: Mode::Fail {
             require_patterns: true,
+            rustfix: true,
         },
         ..Config::rustc("tests/actual_tests")
     };

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -251,7 +251,7 @@ full stderr:
 
 
 tests/actual_tests_bless/aux_proc_macro_no_main.rs FAILED:
-command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--edition" "2021" "--extern" "the_proc_macro=$DIR/$DIR/../../../target/$TMP/tests/actual_tests_bless/aux_proc_macro_no_main/libthe_proc_macro.so" "-L" "$DIR/$DIR/../../../target/$TMP/tests/actual_tests_bless/aux_proc_macro_no_main"
+command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--edition" "2021" "--extern" "the_proc_macro=$DIR/$DIR/../../../target/$TMP/libthe_proc_macro.so" "-L" "$DIR/$DIR/../../../target/$TMP"
 
 There were 1 unmatched diagnostics at tests/actual_tests_bless/aux_proc_macro_no_main.rs:7
     Error: expected one of `!` or `::`, found `<eof>`

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -251,7 +251,7 @@ full stderr:
 
 
 tests/actual_tests_bless/aux_proc_macro_no_main.rs FAILED:
-command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--edition" "2021" "--extern" "the_proc_macro=$DIR/$DIR/../../../target/$TMP/libthe_proc_macro.so" "-L" "$DIR/$DIR/../../../target/$TMP"
+command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--edition" "2021" "--extern" "the_proc_macro=$DIR/$DIR/../../../target/$TMP/tests/actual_tests_bless/auxiliary/libthe_proc_macro.so" "-L" "$DIR/$DIR/../../../target/$TMP/tests/actual_tests_bless/auxiliary"
 
 There were 1 unmatched diagnostics at tests/actual_tests_bless/aux_proc_macro_no_main.rs:7
     Error: expected one of `!` or `::`, found `<eof>`

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -127,10 +127,12 @@ Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/fo
 +  |     arguments to this function are incorrect
    |
  note: function defined here
-~ --> $DIR/$DIR/src/lib.rs:LL:CC
+- --> $DIR/tests/integrations/basic/src/lib.rs:LL:CC
++ --> $DIR/$DIR/src/lib.rs:LL:CC
    |
  1 | pub fn add(left: usize, right: usize) -> usize {
-~  |        ^^^ some expected text that isn't in the actual message░
+-  |        ^^^ some expected text that isn't in the actual message░
++  |        ^^^
  
 -error: aborting doo to previous error
 +error: aborting due to previous error

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -203,8 +203,8 @@ error: test failed, to rerun pass `--test ui_tests`
 
 Caused by:
   process didn't exit successfully: `$DIR/target/ui/debug/ui_tests-HASH` (exit status: 1)
-   Building test dependencies...
 tests/actual_tests_bless/aux_proc_macro_misuse.rs ... FAILED
+   Building test dependencies...
 tests/actual_tests_bless/aux_proc_macro_no_main.rs ... FAILED
 tests/actual_tests_bless/compile_flags_quotes.rs ... FAILED
 tests/actual_tests_bless/compiletest-rs-command.rs ... FAILED
@@ -251,7 +251,7 @@ full stderr:
 
 
 tests/actual_tests_bless/aux_proc_macro_no_main.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--crate-type=lib" "--out-dir" "$TMP "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--edition" "2021" "--extern" "the_proc_macro=$DIR/$DIR/../../../target/$TMP/tests/actual_tests_bless/aux_proc_macro_no_main/libthe_proc_macro.so" "-L" "$DIR/$DIR/../../../target/$TMP/tests/actual_tests_bless/aux_proc_macro_no_main"
+command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--edition" "2021" "--extern" "the_proc_macro=$DIR/$DIR/../../../target/$TMP/tests/actual_tests_bless/aux_proc_macro_no_main/libthe_proc_macro.so" "-L" "$DIR/$DIR/../../../target/$TMP/tests/actual_tests_bless/aux_proc_macro_no_main"
 
 There were 1 unmatched diagnostics at tests/actual_tests_bless/aux_proc_macro_no_main.rs:7
     Error: expected one of `!` or `::`, found `<eof>`
@@ -315,7 +315,7 @@ full stderr:
 
 
 tests/actual_tests_bless/no_main.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--crate-type=lib" "--out-dir" "$TMP "tests/actual_tests_bless/no_main.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/no_main.rs" "--edition" "2021"
 
 fail test got exit status: 0, but expected 1
 
@@ -326,7 +326,7 @@ full stderr:
 
 
 tests/actual_tests_bless/no_main_manual.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--crate-type=lib" "--out-dir" "$TMP "tests/actual_tests_bless/no_main_manual.rs" "--crate-type=bin" "--edition" "2021"
+command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/no_main_manual.rs" "--crate-type=bin" "--edition" "2021"
 
 There were 1 unmatched diagnostics that occurred outside the testfile and had no pattern
     Error: cannot mix `bin` crate type with others
@@ -352,7 +352,7 @@ For more information about this error, try `rustc --explain E0601`.
 
 
 tests/actual_tests_bless/no_test.rs FAILED:
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--test" "--out-dir" "$TMP "tests/actual_tests_bless/no_test.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--test" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/no_test.rs" "--edition" "2021"
 
 fail test got exit status: 0, but expected 1
 

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -583,7 +583,7 @@ test result: FAIL. 1 tests failed, 2 tests passed, 0 ignored, 0 filtered out
 thread 'main' panicked at 'invalid mode/result combo: yolo: Err(tests failed
 
 Location:
-    $DIR/src/lib.rs:LL:CC)', tests/ui_tests_bless.rs:51:18
+    $DIR/src/lib.rs:LL:CC)', tests/ui_tests_bless.rs:52:18
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: test failed, to rerun pass `--test ui_tests_bless`
 Error: failed to parse rustc version info: invalid_foobarlaksdfalsdfj

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -1,4 +1,3 @@
-   Building test dependencies...
 tests/actual_tests/bad_pattern.rs ... FAILED
 tests/actual_tests/executable.rs ... FAILED
 tests/actual_tests/executable_compile_err.rs ... FAILED
@@ -204,7 +203,6 @@ error: test failed, to rerun pass `--test ui_tests`
 Caused by:
   process didn't exit successfully: `$DIR/target/ui/debug/ui_tests-HASH` (exit status: 1)
 tests/actual_tests_bless/aux_proc_macro_misuse.rs ... FAILED
-   Building test dependencies...
 tests/actual_tests_bless/aux_proc_macro_no_main.rs ... FAILED
 tests/actual_tests_bless/compile_flags_quotes.rs ... FAILED
 tests/actual_tests_bless/compiletest-rs-command.rs ... FAILED
@@ -553,7 +551,6 @@ FAILURES:
     tests/actual_tests_bless/unknown_revision2.rs
 
 test result: FAIL. 18 tests failed, 14 tests passed, 3 ignored, 0 filtered out
-   Building test dependencies...
 tests/actual_tests_bless_yolo/revisions_bad.rs (foo) ... ok
 tests/actual_tests_bless_yolo/revisions_bad.rs (bar) ... FAILED
 tests/actual_tests_bless_yolo/rustfix-maybe-incorrect.rs ... ok

--- a/tests/integrations/basic-fail/tests/ui_tests_bless.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_bless.rs
@@ -5,13 +5,14 @@ fn main() -> ui_test::color_eyre::Result<()> {
     for mode in [
         Mode::Fail {
             require_patterns: true,
+            rustfix: true,
         },
-        Mode::Yolo,
+        Mode::Yolo { rustfix: true },
     ] {
         let path = "../../../target";
 
         let root_dir = match mode {
-            Mode::Yolo => "tests/actual_tests_bless_yolo",
+            Mode::Yolo { .. } => "tests/actual_tests_bless_yolo",
             Mode::Fail { .. } => "tests/actual_tests_bless",
             _ => unreachable!(),
         };
@@ -46,7 +47,7 @@ fn main() -> ui_test::color_eyre::Result<()> {
             status_emitter::Text::verbose(),
         );
         match (&result, mode) {
-            (Ok(_), Mode::Yolo) => {}
+            (Ok(_), Mode::Yolo { .. }) => {}
             (Err(_), Mode::Fail { .. }) => {}
             _ => panic!("invalid mode/result combo: {mode}: {result:?}"),
         }

--- a/tests/integrations/basic/Cargo.stderr
+++ b/tests/integrations/basic/Cargo.stderr
@@ -1,4 +1,3 @@
-   Building test dependencies...
 tests/actual_tests/aux_derive.rs ... ok
 tests/actual_tests/aux_proc_macro.rs ... ok
 tests/actual_tests/executable.rs ... ok

--- a/tests/integrations/basic/tests/run_file.rs
+++ b/tests/integrations/basic/tests/run_file.rs
@@ -60,6 +60,7 @@ fn non_utf8() -> Result<()> {
     let mut config = Config::rustc(PathBuf::new());
     config.program = CommandBuilder::cmd("cat");
     config.edition = None;
+    config.host = Some(String::new());
 
     let mut result = ui_test::test_command(config, &path)?;
     ensure!(result.output()?.status.success(), "");


### PR DESCRIPTION
To get there I also only build dependencies if there is a test that wasn't filtered out by doing that during test running.

After this we should be able to refactor our test runner to run on multiple different root directories with multiple different `Config`s, instead of running each `Config` sequentially, and only having parallelism within it.

* [x] try this out with clippy, which is a heavy user of aux builds