### PR TITLE
Allow configuring `rustfix::Filter` independently of the mode

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use regex::bytes::Regex;
 
-use crate::{dependencies::build_dependencies, CommandBuilder, Filter, Match, Mode};
+use crate::{dependencies::build_dependencies, CommandBuilder, Filter, Match, Mode, RustfixMode};
 pub use color_eyre;
 use color_eyre::eyre::Result;
 use std::{
@@ -72,7 +72,7 @@ impl Config {
             root_dir: root_dir.into(),
             mode: Mode::Fail {
                 require_patterns: true,
-                rustfix: true,
+                rustfix: RustfixMode::MachineApplicable,
             },
             program: CommandBuilder::rustc(),
             cfgs: CommandBuilder::cfgs(),
@@ -101,7 +101,7 @@ impl Config {
             edition: None,
             mode: Mode::Fail {
                 require_patterns: true,
-                rustfix: false,
+                rustfix: RustfixMode::Disabled,
             },
             ..Self::rustc(root_dir)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -731,11 +731,11 @@ fn run_rustfix(
         comments.find_one_for_revision(revision, "`no-rustfix` annotations", |r| r.no_rustfix)?;
 
     let global_rustfix = match mode {
-        Mode::Pass | Mode::Run { .. } | Mode::Panic => false,
+        Mode::Pass | Mode::Run { .. } | Mode::Panic => RustfixMode::Disabled,
         Mode::Fail { rustfix, .. } | Mode::Yolo { rustfix } => rustfix,
     };
 
-    let fixed_code = (no_run_rustfix.is_none() && global_rustfix)
+    let fixed_code = (no_run_rustfix.is_none() && global_rustfix.enabled())
         .then_some(())
         .and_then(|()| {
             let suggestions = std::str::from_utf8(stderr)
@@ -748,7 +748,7 @@ fn run_rustfix(
                     rustfix::get_suggestions_from_json(
                         line,
                         &HashSet::new(),
-                        if let Mode::Yolo { .. } = config.mode {
+                        if global_rustfix == RustfixMode::Everything {
                             rustfix::Filter::Everything
                         } else {
                             rustfix::Filter::MachineApplicableOnly

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -5,6 +5,23 @@ use crate::Errored;
 use std::fmt::Display;
 use std::process::ExitStatus;
 
+/// When to run rustfix on tests
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RustfixMode {
+    /// Do not run rustfix on the test
+    Disabled,
+    /// Apply only `MachineApplicable` suggestions emitted by the test
+    MachineApplicable,
+    /// Apply all suggestions emitted by the test
+    Everything,
+}
+
+impl RustfixMode {
+    pub(crate) fn enabled(self) -> bool {
+        self != RustfixMode::Disabled
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 /// Decides what is expected of each test's exit status.
 pub enum Mode {
@@ -21,13 +38,13 @@ pub enum Mode {
     Fail {
         /// Whether failing tests must have error patterns. Set to false if you just care about .stderr output.
         require_patterns: bool,
-        /// Whether to run rustfix on the test if it has machine applicable suggestions.
-        rustfix: bool,
+        /// When to run rustfix on the test
+        rustfix: RustfixMode,
     },
     /// Run the tests, but always pass them as long as all annotations are satisfied and stderr files match.
     Yolo {
-        /// Whether to run
-        rustfix: bool,
+        /// When to run rustfix on the test
+        rustfix: RustfixMode,
     },
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -662,7 +662,10 @@ impl<CommentsType> CommentParser<CommentsType> {
                 });
                 let Some(end) = end else {
                     self.error(s.span(), "`[` without corresponding `]`");
-                    return (Spanned::new(vec![], pattern.span().shrink_to_start()), pattern);
+                    return (
+                        Spanned::new(vec![], pattern.span().shrink_to_start()),
+                        pattern,
+                    );
                 };
                 let (revision, pattern) = s.split_at(end);
                 let revisions = revision.split(',').map(|s| s.trim().to_string()).collect();

--- a/src/status_emitter.rs
+++ b/src/status_emitter.rs
@@ -107,7 +107,7 @@ impl Text {
                                 let Some(spinner) = threads.remove(&msg) else {
                                     // This can happen when a test was not run at all, because it failed directly during
                                     // comment parsing.
-                                    continue
+                                    continue;
                                 };
                                 spinner.set_style(
                                     ProgressStyle::with_template("{prefix} {msg}").unwrap(),

--- a/tests/integrations/basic-fail-mode/tests/ui_tests.rs
+++ b/tests/integrations/basic-fail-mode/tests/ui_tests.rs
@@ -6,7 +6,7 @@ fn main() -> ui_test::color_eyre::Result<()> {
         dependencies_crate_manifest_path: Some("Cargo.toml".into()),
         mode: Mode::Fail {
             require_patterns: true,
-            rustfix: true,
+            rustfix: RustfixMode::MachineApplicable,
         },
         ..Config::rustc("tests/actual_tests")
     };

--- a/tests/integrations/basic-fail/tests/ui_tests_bless.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_bless.rs
@@ -4,9 +4,9 @@ fn main() -> ui_test::color_eyre::Result<()> {
     for mode in [
         Mode::Fail {
             require_patterns: true,
-            rustfix: true,
+            rustfix: RustfixMode::MachineApplicable,
         },
-        Mode::Yolo { rustfix: true },
+        Mode::Yolo { rustfix: RustfixMode::Everything },
     ] {
         let path = "../../../target";
 


### PR DESCRIPTION
Since https://github.com/rust-lang/rust-clippy/pull/11249 was merged we'll be wanting to move clippy from `Yolo` to `Fail` to make the annotations required, but we still want to apply non machine applicable suggestions so this adds an enum to configure rustfix

cc @GuillaumeGomez since https://github.com/rust-lang/rust-clippy/pull/11249#issuecomment-1688502203 will be blocked on this