### PR TITLE
Populate `Config` with `Args` instead of passing it to `run_tests_generic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui_test"
-version = "0.19.1"
+version = "0.20.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A test framework for testing rustc diagnostics output"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -48,7 +48,7 @@ impl CommandBuilder {
         }
     }
 
-    /// Same as [`rustc`], but with arguments for obtaining the cfgs.
+    /// Same as [`CommandBuilder::rustc`], but with arguments for obtaining the cfgs.
     pub fn cfgs() -> Self {
         Self {
             args: vec!["--print".into(), "cfg".into()],

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,8 @@ pub enum Error {
         actual: Vec<u8>,
         /// The contents of the file.
         expected: Vec<u8>,
+        /// A command, that when run, causes the output to get blessed instead of erroring.
+        bless_command: String,
     },
     /// There were errors that don't have a pattern.
     ErrorsWithoutPattern {

--- a/src/status_emitter.rs
+++ b/src/status_emitter.rs
@@ -435,8 +435,14 @@ fn print_error(error: &Error, path: &Path) {
             path: output_path,
             actual,
             expected,
+            bless_command,
         } => {
             println!("{}", "actual output differed from expected".underline());
+            println!(
+                "Execute `{}` to update `{}` to the actual output",
+                bless_command,
+                output_path.display()
+            );
             println!("{}", format!("--- {}", output_path.display()).red());
             println!(
                 "{}",
@@ -615,13 +621,18 @@ fn gha_error(error: &Error, test_path: &str, revision: &str) {
             path: output_path,
             actual,
             expected,
+            bless_command,
         } => {
             if expected.is_empty() {
                 let mut err = github_actions::error(
                     test_path,
                     "test generated output, but there was no output file",
                 );
-                writeln!(err, "you likely need to bless the tests").unwrap();
+                writeln!(
+                    err,
+                    "you likely need to bless the tests with `{bless_command}`"
+                )
+                .unwrap();
                 return;
             }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,7 +9,8 @@ fn main() -> Result<()> {
     let mut config = Config {
         ..Config::cargo(root_dir.clone())
     };
-    let args = Args::test(true)?;
+    let args = Args::test()?;
+    config.with_args(&args, true);
 
     config.program.args = vec![
         "test".into(),
@@ -83,8 +84,7 @@ fn main() -> Result<()> {
                 ..config
             },
         ],
-        args,
-        |path, args, config| {
+        |path, config| {
             let fail = path
                 .parent()
                 .unwrap()
@@ -107,7 +107,7 @@ fn main() -> Result<()> {
                     Mode::Panic => fail,
                     Mode::Run { .. } | Mode::Yolo { .. } | Mode::Fail { .. } => unreachable!(),
                 }
-                && default_filter_by_arg(path, args)
+                && default_any_file_filter(path, config)
         },
         |_, _, _| {},
         (

--- a/tests/integrations/basic-bin/Cargo.lock
+++ b/tests/integrations/basic-bin/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic-bin/tests/ui_tests.rs
+++ b/tests/integrations/basic-bin/tests/ui_tests.rs
@@ -4,6 +4,11 @@ fn main() -> ui_test::color_eyre::Result<()> {
     let path = "../../../target";
     let mut config = Config {
         dependencies_crate_manifest_path: Some("Cargo.toml".into()),
+        output_conflict_handling: if std::env::var_os("BLESS").is_some() {
+            OutputConflictHandling::Bless
+        } else {
+            OutputConflictHandling::Error("cargo test".to_string())
+        },
         ..Config::rustc("tests/actual_tests")
     };
     config.stderr_filter("in ([0-9]m )?[0-9\\.]+s", "");
@@ -21,7 +26,6 @@ fn main() -> ui_test::color_eyre::Result<()> {
 
     run_tests_generic(
         vec![config],
-        Args::test(std::env::var_os("BLESS").is_some())?,
         default_file_filter,
         default_per_file_config,
         // Avoid github actions, as these would end up showing up in `Cargo.stderr`

--- a/tests/integrations/basic-fail-mode/Cargo.lock
+++ b/tests/integrations/basic-fail-mode/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic-fail-mode/tests/ui_tests.rs
+++ b/tests/integrations/basic-fail-mode/tests/ui_tests.rs
@@ -8,6 +8,11 @@ fn main() -> ui_test::color_eyre::Result<()> {
             require_patterns: true,
             rustfix: RustfixMode::MachineApplicable,
         },
+        output_conflict_handling: if std::env::var_os("BLESS").is_some() {
+            OutputConflictHandling::Bless
+        } else {
+            OutputConflictHandling::Error("cargo test".to_string())
+        },
         ..Config::rustc("tests/actual_tests")
     };
     config.stderr_filter("in ([0-9]m )?[0-9\\.]+s", "");
@@ -17,7 +22,6 @@ fn main() -> ui_test::color_eyre::Result<()> {
 
     run_tests_generic(
         vec![config],
-        Args::test(std::env::var_os("BLESS").is_some())?,
         default_file_filter,
         default_per_file_config,
         // Avoid github actions, as these would end up showing up in `Cargo.stderr`

--- a/tests/integrations/basic-fail/Cargo.lock
+++ b/tests/integrations/basic-fail/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -9,7 +9,7 @@ Caused by:
 thread 'main' panicked at 'invalid mode/result combo: yolo: Err(tests failed
 
 Location:
-    $DIR/src/lib.rs:LL:CC)', tests/ui_tests_bless.rs:48:18
+    $DIR/src/lib.rs:LL:CC)', tests/ui_tests_bless.rs:52:18
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: test failed, to rerun pass `--test ui_tests_bless`
 Error: failed to parse rustc version info: invalid_foobarlaksdfalsdfj

--- a/tests/integrations/basic-fail/Cargo.stdout
+++ b/tests/integrations/basic-fail/Cargo.stdout
@@ -57,6 +57,7 @@ tests/actual_tests/executable.rs FAILED:
 command: "$CMD"
 
 actual output differed from expected
+Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/executable.stdout` to the actual output
 --- tests/actual_tests/executable.stdout
 +++ <stdout output>
 -69
@@ -75,6 +76,7 @@ command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../..
 run(0) test got exit status: 1, but expected 0
 
 actual output differed from expected
+Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/executable_compile_err.stderr` to the actual output
 --- tests/actual_tests/executable_compile_err.stderr
 +++ <stderr output>
 +error: this file contains an unclosed delimiter
@@ -145,6 +147,7 @@ tests/actual_tests/foomp.rs FAILED:
 command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/foomp.rs" "--edition" "2021"
 
 actual output differed from expected
+Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/foomp.stderr` to the actual output
 --- tests/actual_tests/foomp.stderr
 +++ <stderr output>
  error[E0308]: mismatched types
@@ -196,6 +199,7 @@ tests/actual_tests/foomp2.rs FAILED:
 command: "$CMD"
 
 actual output differed from expected
+Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/foomp2.fixed` to the actual output
 --- tests/actual_tests/foomp2.fixed
 +++ <fixed output>
 -this is just a test file showing that

--- a/tests/integrations/basic-fail/tests/ui_tests.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests.rs
@@ -4,6 +4,11 @@ fn main() -> ui_test::color_eyre::Result<()> {
     let path = "../../../target";
     let mut config = Config {
         dependencies_crate_manifest_path: Some("Cargo.toml".into()),
+        // Never bless integrations-fail tests, we want to see stderr mismatches
+        output_conflict_handling: OutputConflictHandling::Error(
+            "DO NOT BLESS. These are meant to fail".into(),
+        ),
+
         ..Config::rustc("tests/actual_tests")
     };
 
@@ -20,8 +25,6 @@ fn main() -> ui_test::color_eyre::Result<()> {
 
     run_tests_generic(
         vec![config],
-        // Never bless integrations-fail tests, we want to see stderr mismatches
-        Args::test(false)?,
         default_file_filter,
         default_per_file_config,
         // Avoid github actions, as these would end up showing up in `Cargo.stderr`

--- a/tests/integrations/basic-fail/tests/ui_tests_bless.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_bless.rs
@@ -20,6 +20,11 @@ fn main() -> ui_test::color_eyre::Result<()> {
 
         let mut config = Config {
             dependencies_crate_manifest_path: Some("Cargo.toml".into()),
+            output_conflict_handling: if std::env::var_os("BLESS").is_some() {
+                OutputConflictHandling::Bless
+            } else {
+                OutputConflictHandling::Error("cargo test".to_string())
+            },
             mode,
             ..Config::rustc(root_dir)
         };
@@ -36,7 +41,6 @@ fn main() -> ui_test::color_eyre::Result<()> {
         config.path_stderr_filter(&std::path::Path::new(path), "$DIR");
         let result = run_tests_generic(
             vec![config],
-            Args::test(std::env::var_os("BLESS").is_some())?,
             default_file_filter,
             default_per_file_config,
             // Avoid github actions, as these would end up showing up in `Cargo.stderr`

--- a/tests/integrations/basic-fail/tests/ui_tests_invalid_program.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_invalid_program.rs
@@ -3,13 +3,15 @@ use ui_test::*;
 fn main() -> ui_test::color_eyre::Result<()> {
     let config = Config {
         program: CommandBuilder::cmd("invalid_foobarlaksdfalsdfj"),
+        // Never bless integrations-fail tests, we want to see stderr mismatches
+        output_conflict_handling: OutputConflictHandling::Error(
+            "DO NOT BLESS. These are meant to fail".into(),
+        ),
         ..Config::rustc("tests/actual_tests")
     };
 
     run_tests_generic(
         vec![config],
-        // Never bless integrations-fail tests, we want to see stderr mismatches
-        Args::test(false)?,
         default_file_filter,
         default_per_file_config,
         // Avoid github actions, as these would end up showing up in `Cargo.stderr`

--- a/tests/integrations/basic-fail/tests/ui_tests_invalid_program2.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_invalid_program2.rs
@@ -3,14 +3,16 @@ use ui_test::*;
 fn main() -> ui_test::color_eyre::Result<()> {
     let config = Config {
         program: CommandBuilder::cmd("invalid_foobarlaksdfalsdfj"),
+        // Never bless integrations-fail tests, we want to see stderr mismatches
+        output_conflict_handling: OutputConflictHandling::Error(
+            "DO NOT BLESS. These are meant to fail".into(),
+        ),
         host: Some("foo".into()),
         ..Config::rustc("tests/actual_tests")
     };
 
     run_tests_generic(
         vec![config],
-        // Never bless integrations-fail tests, we want to see stderr mismatches
-        Args::test(false)?,
         default_file_filter,
         default_per_file_config,
         // Avoid github actions, as these would end up showing up in `Cargo.stderr`

--- a/tests/integrations/basic/Cargo.lock
+++ b/tests/integrations/basic/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic/tests/ui_tests.rs
+++ b/tests/integrations/basic/tests/ui_tests.rs
@@ -4,6 +4,11 @@ fn main() -> ui_test::color_eyre::Result<()> {
     let path = "../../../target";
     let mut config = Config {
         dependencies_crate_manifest_path: Some("Cargo.toml".into()),
+        output_conflict_handling: if std::env::var_os("BLESS").is_some() {
+            OutputConflictHandling::Bless
+        } else {
+            OutputConflictHandling::Error("cargo test".to_string())
+        },
         ..Config::rustc("tests/actual_tests")
     };
     config.stderr_filter("in ([0-9]m )?[0-9\\.]+s", "");
@@ -19,7 +24,6 @@ fn main() -> ui_test::color_eyre::Result<()> {
 
     run_tests_generic(
         vec![config],
-        Args::test(std::env::var_os("BLESS").is_some())?,
         default_file_filter,
         default_per_file_config,
         // Avoid github actions, as these would end up showing up in `Cargo.stderr`


### PR DESCRIPTION
`Args` now solely parses arguments and is used to fill in fields on `Config`, the default number of test threads is also moved into `run_tests_generic`

This reintroduces `OutputConflictHandling` as the command string in the error variant is nice to have