### PR TITLE
Move the bless command to a field in Config

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -69,7 +69,7 @@ pub(crate) fn build_dependencies(config: &Config) -> Result<Dependencies> {
             .unwrap(),
     ) {
         (_, Mode::Yolo { .. }) => {}
-        (OutputConflictHandling::Error(_), _) => {
+        (OutputConflictHandling::Error, _) => {
             cmd.arg("--locked");
         }
         _ => {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ pub enum Error {
         /// The contents of the file.
         expected: Vec<u8>,
         /// A command, that when run, causes the output to get blessed instead of erroring.
-        bless_command: String,
+        bless_command: Option<String>,
     },
     /// There were errors that don't have a pattern.
     ErrorsWithoutPattern {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ pub fn run_tests(mut config: Config) -> Result<()> {
         Format::Terse => status_emitter::Text::quiet(),
         Format::Pretty => status_emitter::Text::verbose(),
     };
-    config.with_args(&args, true);
+    config.with_args(&args);
 
     run_tests_generic(
         vec![config],
@@ -1183,14 +1183,14 @@ fn check_output(
     let output = normalize(output, comments, revision, kind);
     let path = output_path(path, comments, revised(revision, kind), target, revision);
     match &config.output_conflict_handling {
-        OutputConflictHandling::Error(bless_command) => {
+        OutputConflictHandling::Error => {
             let expected_output = std::fs::read(&path).unwrap_or_default();
             if output != expected_output {
                 errors.push(Error::OutputDiffers {
                     path: path.clone(),
                     actual: output.clone(),
                     expected: expected_output,
-                    bless_command: bless_command.clone(),
+                    bless_command: config.bless_command.clone(),
                 });
             }
         }

--- a/src/status_emitter.rs
+++ b/src/status_emitter.rs
@@ -466,11 +466,13 @@ fn print_error(error: &Error, path: &Path) {
             bless_command,
         } => {
             print_error_header("actual output differed from expected");
-            println!(
-                "Execute `{}` to update `{}` to the actual output",
-                bless_command,
-                output_path.display()
-            );
+            if let Some(bless_command) = bless_command {
+                println!(
+                    "Execute `{}` to update `{}` to the actual output",
+                    bless_command,
+                    output_path.display()
+                );
+            }
             println!("{}", format!("--- {}", output_path.display()).red());
             println!(
                 "{}",
@@ -670,11 +672,13 @@ fn gha_error(error: &Error, test_path: &str, revision: &str) {
                     test_path,
                     "test generated output, but there was no output file",
                 );
-                writeln!(
-                    err,
-                    "you likely need to bless the tests with `{bless_command}`"
-                )
-                .unwrap();
+                if let Some(bless_command) = bless_command {
+                    writeln!(
+                        err,
+                        "you likely need to bless the tests with `{bless_command}`"
+                    )
+                    .unwrap();
+                }
                 return;
             }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,9 +6,12 @@ use ui_test::{spanned::Spanned, *};
 fn main() -> Result<()> {
     let path = Path::new(file!()).parent().unwrap();
     let root_dir = path.join("integrations");
-    let mut config = Config::cargo(root_dir.clone());
+    let mut config = Config {
+        bless_command: Some("cargo test".to_string()),
+        ..Config::cargo(root_dir.clone())
+    };
     let args = Args::test()?;
-    config.with_args(&args, true);
+    config.with_args(&args);
 
     config.program.args = vec![
         "test".into(),

--- a/tests/integrations/basic-bin/tests/ui_tests.rs
+++ b/tests/integrations/basic-bin/tests/ui_tests.rs
@@ -7,8 +7,9 @@ fn main() -> ui_test::color_eyre::Result<()> {
         output_conflict_handling: if std::env::var_os("BLESS").is_some() {
             OutputConflictHandling::Bless
         } else {
-            OutputConflictHandling::Error("cargo test".to_string())
+            OutputConflictHandling::Error
         },
+        bless_command: Some("cargo test".to_string()),
         ..Config::rustc("tests/actual_tests")
     };
     config.stderr_filter("in ([0-9]m )?[0-9\\.]+s", "");

--- a/tests/integrations/basic-fail-mode/tests/ui_tests.rs
+++ b/tests/integrations/basic-fail-mode/tests/ui_tests.rs
@@ -8,8 +8,9 @@ fn main() -> ui_test::color_eyre::Result<()> {
         output_conflict_handling: if std::env::var_os("BLESS").is_some() {
             OutputConflictHandling::Bless
         } else {
-            OutputConflictHandling::Error("cargo test".to_string())
+            OutputConflictHandling::Error
         },
+        bless_command: Some("cargo test".to_string()),
         ..Config::rustc("tests/actual_tests")
     };
     config.comment_defaults.base().mode = Spanned::dummy(Mode::Fail {

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -6,7 +6,7 @@ error: test failed, to rerun pass `--test ui_tests`
 
 Caused by:
   process didn't exit successfully: `$DIR/target/ui/tests/integrations/basic-fail/debug/deps/ui_tests-HASH` (exit status: 1)
-thread 'main' panicked at tests/ui_tests_bless.rs:52:18:
+thread 'main' panicked at tests/ui_tests_bless.rs:53:18:
 invalid mode/result combo: yolo: Err(tests failed
 
 Location:

--- a/tests/integrations/basic-fail/tests/ui_tests.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests.rs
@@ -5,10 +5,8 @@ fn main() -> ui_test::color_eyre::Result<()> {
     let mut config = Config {
         dependencies_crate_manifest_path: Some("Cargo.toml".into()),
         // Never bless integrations-fail tests, we want to see stderr mismatches
-        output_conflict_handling: OutputConflictHandling::Error(
-            "DO NOT BLESS. These are meant to fail".into(),
-        ),
-
+        output_conflict_handling: OutputConflictHandling::Error,
+        bless_command: Some("DO NOT BLESS. These are meant to fail".to_string()),
         ..Config::rustc("tests/actual_tests")
     };
 

--- a/tests/integrations/basic-fail/tests/ui_tests_bless.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_bless.rs
@@ -23,8 +23,9 @@ fn main() -> ui_test::color_eyre::Result<()> {
             output_conflict_handling: if std::env::var_os("BLESS").is_some() {
                 OutputConflictHandling::Bless
             } else {
-                OutputConflictHandling::Error("cargo test".to_string())
+                OutputConflictHandling::Error
             },
+            bless_command: Some("cargo test".to_string()),
             ..Config::rustc(root_dir)
         };
         config.comment_defaults.base().mode = Spanned::dummy(mode).into();

--- a/tests/integrations/basic-fail/tests/ui_tests_invalid_program.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_invalid_program.rs
@@ -4,9 +4,8 @@ fn main() -> ui_test::color_eyre::Result<()> {
     let config = Config {
         program: CommandBuilder::cmd("invalid_foobarlaksdfalsdfj"),
         // Never bless integrations-fail tests, we want to see stderr mismatches
-        output_conflict_handling: OutputConflictHandling::Error(
-            "DO NOT BLESS. These are meant to fail".into(),
-        ),
+        output_conflict_handling: OutputConflictHandling::Error,
+        bless_command: Some("DO NOT BLESS. These are meant to fail".to_string()),
         ..Config::rustc("tests/actual_tests")
     };
 

--- a/tests/integrations/basic-fail/tests/ui_tests_invalid_program2.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_invalid_program2.rs
@@ -4,9 +4,8 @@ fn main() -> ui_test::color_eyre::Result<()> {
     let config = Config {
         program: CommandBuilder::cmd("invalid_foobarlaksdfalsdfj"),
         // Never bless integrations-fail tests, we want to see stderr mismatches
-        output_conflict_handling: OutputConflictHandling::Error(
-            "DO NOT BLESS. These are meant to fail".into(),
-        ),
+        output_conflict_handling: OutputConflictHandling::Error,
+        bless_command: Some("DO NOT BLESS. These are meant to fail".to_string()),
         host: Some("foo".into()),
         ..Config::rustc("tests/actual_tests")
     };

--- a/tests/integrations/basic/tests/ui_tests.rs
+++ b/tests/integrations/basic/tests/ui_tests.rs
@@ -7,8 +7,9 @@ fn main() -> ui_test::color_eyre::Result<()> {
         output_conflict_handling: if std::env::var_os("BLESS").is_some() {
             OutputConflictHandling::Bless
         } else {
-            OutputConflictHandling::Error("cargo test".to_string())
+            OutputConflictHandling::Error
         },
+        bless_command: Some("cargo test".to_string()),
         ..Config::rustc("tests/actual_tests")
     };
     config.stderr_filter("in ([0-9]m )?[0-9\\.]+s", "");

--- a/tests/integrations/cargo-run/tests/ui_tests.rs
+++ b/tests/integrations/cargo-run/tests/ui_tests.rs
@@ -5,8 +5,9 @@ fn main() -> ui_test::color_eyre::Result<()> {
         output_conflict_handling: if std::env::var_os("BLESS").is_some() {
             OutputConflictHandling::Bless
         } else {
-            OutputConflictHandling::Error("cargo test".to_string())
+            OutputConflictHandling::Error
         },
+        bless_command: Some("cargo test".to_string()),
         ..Config::cargo("tests/actual_tests")
     };
     config.comment_defaults.base().mode = Spanned::dummy(Mode::Panic).into();


### PR DESCRIPTION
The usage in clippy showed that #157 made the API a bit awkward with regards to the bless command and conflict handling modes, this takes it from

```rust
let mut config = Config {
    ..
};
config.with_args(&args, /* bless by default */ false);
if let OutputConflictHandling::Error(err) = &mut config.output_conflict_handling {
    *err = "cargo uibless".into();
}
```

to

```rust
let mut config = Config {
    output_conflict_handling: OutputConflictHandling::Error,
    bless_command: Some("cargo uibless".into()),
    ..
};
config.with_args(&args)
```

The default conflict handling is now only specified in the `Config`, no more `bool` in `with_args`

It's a separate (optional) field because in order for `OutputConflictHandling::Bless` +  `--check` to work it had to supply a bless command of its own, but there's not really a sensible default suggestion we can make