### PR TITLE
Remove `$DIR` replacement of test's parent directory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1196,7 +1196,7 @@ fn check_output(
     revision: &str,
 ) -> PathBuf {
     let target = config.target.as_ref().unwrap();
-    let output = normalize(path, output, filters, comments, revision, kind);
+    let output = normalize(output, filters, comments, revision, kind);
     let path = output_path(path, comments, revised(revision, kind), target, revision);
     match &config.output_conflict_handling {
         OutputConflictHandling::Error(bless_command) => {
@@ -1287,20 +1287,13 @@ fn get_pointer_width(triple: &str) -> u8 {
 }
 
 fn normalize(
-    path: &Path,
     text: &[u8],
     filters: &Filter,
     comments: &Comments,
     revision: &str,
     kind: &'static str,
 ) -> Vec<u8> {
-    // Useless paths
-    let path_filter = (Match::from(path.parent().unwrap()), b"$DIR" as &[u8]);
-    let filters = filters.iter().chain(std::iter::once(&path_filter));
     let mut text = text.to_owned();
-    if let Some(lib_path) = option_env!("RUSTC_LIB_PATH") {
-        text = text.replace(lib_path, "RUSTLIB");
-    }
 
     for (rule, replacement) in filters {
         text = rule.replace_all(&text, replacement).into_owned();

--- a/tests/integrations/basic-bin/tests/actual_tests/foomp.stderr
+++ b/tests/integrations/basic-bin/tests/actual_tests/foomp.stderr
@@ -1,5 +1,5 @@
 error[E0432]: unresolved import `basic_bin`
- --> $DIR/foomp.rs:1:5
+ --> tests/actual_tests/foomp.rs:1:5
   |
 1 | use basic_bin::add;
   |     ^^^^^^^^^ use of undeclared crate or module `basic_bin`

--- a/tests/integrations/basic-fail-mode/tests/actual_tests/foomp.stderr
+++ b/tests/integrations/basic-fail-mode/tests/actual_tests/foomp.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/foomp.rs:4:9
+ --> tests/actual_tests/foomp.rs:4:9
   |
 4 |     add("42", 3);
   |     --- ^^^^ expected `usize`, found `&str`

--- a/tests/integrations/basic-fail/Cargo.stderr
+++ b/tests/integrations/basic-fail/Cargo.stderr
@@ -5,7 +5,7 @@ Location:
 error: test failed, to rerun pass `--test ui_tests`
 
 Caused by:
-  process didn't exit successfully: `$DIR/target/ui/$DIR/debug/deps/ui_tests-HASH` (exit status: 1)
+  process didn't exit successfully: `$DIR/target/ui/tests/integrations/basic-fail/debug/deps/ui_tests-HASH` (exit status: 1)
 thread 'main' panicked at tests/ui_tests_bless.rs:52:18:
 invalid mode/result combo: yolo: Err(tests failed
 
@@ -22,7 +22,7 @@ Location:
 error: test failed, to rerun pass `--test ui_tests_invalid_program`
 
 Caused by:
-  process didn't exit successfully: `$DIR/target/ui/$DIR/debug/deps/ui_tests_invalid_program-HASH` (exit status: 1)
+  process didn't exit successfully: `$DIR/target/ui/tests/integrations/basic-fail/debug/deps/ui_tests_invalid_program-HASH` (exit status: 1)
 Error: tests failed
 
 Location:
@@ -30,7 +30,7 @@ Location:
 error: test failed, to rerun pass `--test ui_tests_invalid_program2`
 
 Caused by:
-  process didn't exit successfully: `$DIR/target/ui/$DIR/debug/deps/ui_tests_invalid_program2-HASH` (exit status: 1)
+  process didn't exit successfully: `$DIR/target/ui/tests/integrations/basic-fail/debug/deps/ui_tests_invalid_program2-HASH` (exit status: 1)
 error: 4 targets failed:
     `--test ui_tests`
     `--test ui_tests_bless`

--- a/tests/integrations/basic-fail/Cargo.stdout
+++ b/tests/integrations/basic-fail/Cargo.stdout
@@ -15,7 +15,7 @@ tests/actual_tests/pattern_too_many_arrow.rs ... FAILED
 tests/actual_tests/rustc_ice.rs ... FAILED
 
 FAILED TEST: tests/actual_tests/bad_pattern.rs
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/bad_pattern.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/bad_pattern.rs" "--edition" "2021"
 
 error: `miesmätsched types` not found in diagnostics on line 4
  --> tests/actual_tests/bad_pattern.rs:5:17
@@ -41,7 +41,7 @@ error[E0308]: mismatched types
   |     arguments to this function are incorrect
   |
 note: function defined here
- --> $DIR/$DIR/src/lib.rs:LL:CC
+ --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC
   |
 1 | pub fn add(left: usize, right: usize) -> usize {
   |        ^^^
@@ -72,7 +72,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests/executable_compile_err.rs
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/executable_compile_err.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/executable_compile_err.rs" "--edition" "2021"
 
 error: pass test got exit status: 1, but expected 0
 
@@ -81,7 +81,7 @@ Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/ex
 --- tests/actual_tests/executable_compile_err.stderr
 +++ <stderr output>
 +error: this file contains an unclosed delimiter
-+ --> $DIR/executable_compile_err.rs:4:2
++ --> tests/actual_tests/executable_compile_err.rs:4:2
 +  |
 +3 | fn main() {
 +  |           - unclosed delimiter
@@ -116,7 +116,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests/exit_code_fail.rs
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/exit_code_fail.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/exit_code_fail.rs" "--edition" "2021"
 
 error: fail test got exit status: 0, but expected 1
 
@@ -145,14 +145,14 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests/foomp.rs
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/foomp.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/foomp.rs" "--edition" "2021"
 
 error: actual output differed from expected
 Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/foomp.stderr` to the actual output
 --- tests/actual_tests/foomp.stderr
 +++ <stderr output>
  error[E0308]: mismatched types
-  --> $DIR/foomp.rs:4:9
+  --> tests/actual_tests/foomp.rs:4:9
    |
  4 |     add("42", 3);
    |     --- ^^^^ expected `usize`, found `&str`
@@ -161,10 +161,10 @@ Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/fo
    |
  note: function defined here
 - --> $DIR/tests/integrations/basic/src/lib.rs:LL:CC
-+ --> $DIR/$DIR/src/lib.rs:LL:CC
++ --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC
    |
  1 | pub fn add(left: usize, right: usize) -> usize {
--  |        ^^^ some expected text that isn't in the actual message░
+-  |        ^^^ some expected text that isn't in the actual message
 +  |        ^^^
  
 -error: aborting doo to previous error
@@ -183,7 +183,7 @@ error[E0308]: mismatched types
   |     arguments to this function are incorrect
   |
 note: function defined here
- --> $DIR/$DIR/src/lib.rs:LL:CC
+ --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC
   |
 1 | pub fn add(left: usize, right: usize) -> usize {
   |        ^^^
@@ -230,7 +230,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests/rustc_ice.rs
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/rustc_ice.rs" "-Ztreat-err-as-bug" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/rustc_ice.rs" "-Ztreat-err-as-bug" "--edition" "2021"
 
 error: fail test got exit status: 101, but expected 1
 
@@ -356,7 +356,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests_bless/aux_proc_macro_no_main.rs
-command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--edition" "2021" "--extern" "the_proc_macro=$DIR/$DIR/../../../target/$TMP/tests/actual_tests_bless/auxiliary/libthe_proc_macro.so" "-L" "$DIR/$DIR/../../../target/$TMP/tests/actual_tests_bless/auxiliary"
+command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--edition" "2021" "--extern" "the_proc_macro=$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary/libthe_proc_macro.so" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary"
 
 error: there were 1 unmatched diagnostics
  --> tests/actual_tests_bless/aux_proc_macro_no_main.rs:7:8
@@ -452,7 +452,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests_bless/no_main.rs
-command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/no_main.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/no_main.rs" "--edition" "2021"
 
 error: fail test got exit status: 0, but expected 1
 
@@ -465,7 +465,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests_bless/no_main_manual.rs
-command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/no_main_manual.rs" "--crate-type=bin" "--edition" "2021"
+command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/no_main_manual.rs" "--crate-type=bin" "--edition" "2021"
 
 error: there were 1 unmatched diagnostics that occurred outside the testfile and had no pattern
     Error: cannot mix `bin` crate type with others
@@ -497,7 +497,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests_bless/no_test.rs
-command: "rustc" "--error-format=json" "--test" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/no_test.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--test" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/no_test.rs" "--edition" "2021"
 
 error: fail test got exit status: 0, but expected 1
 
@@ -537,7 +537,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests_bless/pass_with_annotation.rs
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/pass_with_annotation.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/pass_with_annotation.rs" "--edition" "2021"
 
 error: `the cake is a lie` not found in diagnostics on line 3
  --> tests/actual_tests_bless/pass_with_annotation.rs:3:12
@@ -603,7 +603,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests_bless/revisions_bad.rs (revision `bar`)
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisions_bad.rs" "--cfg=bar" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/revisions_bad.rs" "--cfg=bar" "--edition" "2021"
 
 error: ``main` function not found in crate `revisions_bad`` not found in diagnostics outside the testfile
  --> tests/actual_tests_bless/revisions_bad.rs:4:31
@@ -635,7 +635,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `a`)
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/rustfix-fail-revisions.a.fixed" "--cfg=a" "--edition" "2021" "--crate-name" "rustfix_fail_revisions"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/rustfix-fail-revisions.a.fixed" "--cfg=a" "--edition" "2021" "--crate-name" "rustfix_fail_revisions"
 
 error: rustfix failed with exit status: 1
 
@@ -665,7 +665,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `b`)
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/rustfix-fail-revisions.b.fixed" "--cfg=b" "--edition" "2021" "--crate-name" "rustfix_fail_revisions"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/rustfix-fail-revisions.b.fixed" "--cfg=b" "--edition" "2021" "--crate-name" "rustfix_fail_revisions"
 
 error: rustfix failed with exit status: 1
 
@@ -695,7 +695,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests_bless/rustfix-fail.rs
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/rustfix-fail.fixed" "--edition" "2021" "--crate-name" "rustfix_fail"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/rustfix-fail.fixed" "--edition" "2021" "--crate-name" "rustfix_fail"
 
 error: rustfix failed with exit status: 1
 
@@ -785,7 +785,7 @@ tests/actual_tests_bless_yolo/revisions_bad.rs (revision `bar`) ... FAILED
 tests/actual_tests_bless_yolo/rustfix-maybe-incorrect.rs ... ok
 
 FAILED TEST: tests/actual_tests_bless_yolo/revisions_bad.rs (revision `bar`)
-command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/$DIR/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless_yolo/revisions_bad.rs" "--cfg=bar" "--edition" "2021"
+command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless_yolo/revisions_bad.rs" "--cfg=bar" "--edition" "2021"
 
 error: ``main` function not found in crate `revisions_bad`` not found in diagnostics outside the testfile
  --> tests/actual_tests_bless_yolo/revisions_bad.rs:4:31

--- a/tests/integrations/basic-fail/tests/actual_tests/bad_pattern.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests/bad_pattern.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/bad_pattern.rs:4:9
+ --> tests/actual_tests/bad_pattern.rs:4:9
   |
 4 |     add("42", 3);
   |     --- ^^^^ expected `usize`, found `&str`

--- a/tests/integrations/basic-fail/tests/actual_tests/foomp.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests/foomp.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/foomp.rs:4:9
+ --> tests/actual_tests/foomp.rs:4:9
   |
 4 |     add("42", 3);
   |     --- ^^^^ expected `usize`, found `&str`
@@ -8,7 +8,7 @@ note: function defined here
  --> $DIR/tests/integrations/basic/src/lib.rs:1:8
   |
 1 | pub fn add(left: usize, right: usize) -> usize {
-  |        ^^^ some expected text that isn't in the actual message	
+  |        ^^^ some expected text that isn't in the actual message
 
 error: aborting doo to previous error
 

--- a/tests/integrations/basic-fail/tests/actual_tests/foomp2.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests/foomp2.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/foomp2.rs:4:9
+ --> tests/actual_tests/foomp2.rs:4:9
   |
 4 |     add("42", 3);
   |     --- ^^^^ expected `usize`, found `&str`

--- a/tests/integrations/basic-fail/tests/actual_tests/rustc_ice.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests/rustc_ice.stderr
@@ -1,5 +1,5 @@
 error: internal compiler error: no errors reported for args
- --> $DIR/rustc_ice.rs:8:5
+ --> tests/actual_tests/rustc_ice.rs:8:5
   |
 8 |     add("42", 3);
   |     ^^^^^^^^^^^^

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/aux_proc_macro_no_main.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/aux_proc_macro_no_main.stderr
@@ -1,5 +1,5 @@
 error: expected one of `!` or `::`, found `<eof>`
- --> $DIR/aux_proc_macro_no_main.rs:7:8
+ --> tests/actual_tests_bless/aux_proc_macro_no_main.rs:7:8
   |
 7 | thing!(cake);
   |        ^^^^ expected one of `!` or `::`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/failing_executable.run.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/failing_executable.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at $DIR/failing_executable.rs:4:5:
+thread 'main' panicked at tests/actual_tests_bless/failing_executable.rs:4:5:
 assertion `left == right` failed
   left: 5
  right: 6

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/foomp_aux.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/foomp_aux.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/foomp_aux.rs:6:9
+ --> tests/actual_tests_bless/foomp_aux.rs:6:9
   |
 6 |     add("42", 3);
   |     --- ^^^^ expected `u8`, found `&str`
@@ -7,7 +7,7 @@ error[E0308]: mismatched types
   |     arguments to this function are incorrect
   |
 note: function defined here
- --> $DIR/tests/integrations/basic-fail/$DIR/auxiliary/foomp.rs:1:8
+ --> $DIR/tests/integrations/basic-fail/tests/actual_tests_bless/auxiliary/foomp.rs:1:8
   |
 1 | pub fn add(_: u8, _: u8) {}
   |        ^^^

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/no_main_manual.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/no_main_manual.stderr
@@ -1,10 +1,10 @@
 error: cannot mix `bin` crate type with others
 
 error[E0601]: `main` function not found in crate `no_main_manual`
- --> $DIR/no_main_manual.rs:3:16
+ --> tests/actual_tests_bless/no_main_manual.rs:3:16
   |
 3 | pub fn foo() {}
-  |                ^ consider adding a `main` function to `$DIR/no_main_manual.rs`
+  |                ^ consider adding a `main` function to `tests/actual_tests_bless/no_main_manual.rs`
 
 error: aborting due to 2 previous errors
 

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/revisioned_executable_panic.run.panic.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/revisioned_executable_panic.run.panic.stderr
@@ -1,3 +1,3 @@
-thread 'main' panicked at $DIR/revisioned_executable_panic.rs:6:5:
+thread 'main' panicked at tests/actual_tests_bless/revisioned_executable_panic.rs:6:5:
 explicit panic
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/revisioned_executable_panic.run.run.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/revisioned_executable_panic.run.run.stderr
@@ -1,3 +1,3 @@
-thread 'main' panicked at $DIR/revisioned_executable_panic.rs:6:5:
+thread 'main' panicked at tests/actual_tests_bless/revisioned_executable_panic.rs:6:5:
 explicit panic
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/revisions.bar.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/revisions.bar.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/revisions.rs:11:9
+  --> tests/actual_tests_bless/revisions.rs:11:9
    |
 11 |     add("42", 3);
    |     --- ^^^^ expected `usize`, found `&str`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/revisions.foo.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/revisions.foo.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/revisions.rs:6:9
+ --> tests/actual_tests_bless/revisions.rs:6:9
   |
 6 |     add("42", 3);
   |     --- ^^^^ expected `usize`, found `&str`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_bad.bar.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_bad.bar.stderr
@@ -1,8 +1,8 @@
 error[E0601]: `main` function not found in crate `revisions_bad`
-  --> $DIR/revisions_bad.rs:10:2
+  --> tests/actual_tests_bless/revisions_bad.rs:10:2
    |
 10 | }
-   |  ^ consider adding a `main` function to `$DIR/revisions_bad.rs`
+   |  ^ consider adding a `main` function to `tests/actual_tests_bless/revisions_bad.rs`
 
 error: aborting due to previous error
 

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_bad.foo.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_bad.foo.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/revisions_bad.rs:8:9
+ --> tests/actual_tests_bless/revisions_bad.rs:8:9
   |
 8 |     add("42", 3);
   |     --- ^^^^ expected `usize`, found `&str`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_filter2.bar.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_filter2.bar.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/revisions_filter2.rs:12:9
+  --> tests/actual_tests_bless/revisions_filter2.rs:12:9
    |
 12 |     add("42", 3);
    |     --- ^^^^ expected `usize`, found `&str`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_multiple_per_annotation.bar.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_multiple_per_annotation.bar.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/revisions_multiple_per_annotation.rs:5:9
+ --> tests/actual_tests_bless/revisions_multiple_per_annotation.rs:5:9
   |
 5 |     add("42", 3);
   |     --- ^^^^ expected `usize`, found `&str`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_multiple_per_annotation.foo.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_multiple_per_annotation.foo.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/revisions_multiple_per_annotation.rs:5:9
+ --> tests/actual_tests_bless/revisions_multiple_per_annotation.rs:5:9
   |
 5 |     add("42", 3);
   |     --- ^^^^ expected `usize`, found `&str`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_same_everywhere.bar.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_same_everywhere.bar.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/revisions_same_everywhere.rs:5:9
+ --> tests/actual_tests_bless/revisions_same_everywhere.rs:5:9
   |
 5 |     add("42", 3);
   |     --- ^^^^ expected `usize`, found `&str`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_same_everywhere.foo.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/revisions_same_everywhere.foo.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/revisions_same_everywhere.rs:5:9
+ --> tests/actual_tests_bless/revisions_same_everywhere.rs:5:9
   |
 5 |     add("42", 3);
   |     --- ^^^^ expected `usize`, found `&str`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/run_panic.run.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/run_panic.run.stderr
@@ -1,3 +1,3 @@
-thread 'main' panicked at $DIR/run_panic.rs:4:5:
+thread 'main' panicked at tests/actual_tests_bless/run_panic.rs:4:5:
 explicit panic
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/rustfix-fail-revisions.a.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/rustfix-fail-revisions.a.stderr
@@ -1,5 +1,5 @@
 error: expected `,` following `match` arm
- --> $DIR/rustfix-fail-revisions.rs:6:27
+ --> tests/actual_tests_bless/rustfix-fail-revisions.rs:6:27
   |
 6 |         0 => String::new()
   |                           ^ help: missing a comma here to end this `match` arm: `,`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/rustfix-fail-revisions.b.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/rustfix-fail-revisions.b.stderr
@@ -1,5 +1,5 @@
 error: expected `,` following `match` arm
- --> $DIR/rustfix-fail-revisions.rs:6:27
+ --> tests/actual_tests_bless/rustfix-fail-revisions.rs:6:27
   |
 6 |         0 => String::new()
   |                           ^ help: missing a comma here to end this `match` arm: `,`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/rustfix-fail.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/rustfix-fail.stderr
@@ -1,5 +1,5 @@
 error: expected `,` following `match` arm
- --> $DIR/rustfix-fail.rs:5:27
+ --> tests/actual_tests_bless/rustfix-fail.rs:5:27
   |
 5 |         0 => String::new()
   |                           ^ help: missing a comma here to end this `match` arm: `,`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/revisions_bad.bar.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/revisions_bad.bar.stderr
@@ -1,8 +1,8 @@
 error[E0601]: `main` function not found in crate `revisions_bad`
-  --> $DIR/revisions_bad.rs:10:2
+  --> tests/actual_tests_bless_yolo/revisions_bad.rs:10:2
    |
 10 | }
-   |  ^ consider adding a `main` function to `$DIR/revisions_bad.rs`
+   |  ^ consider adding a `main` function to `tests/actual_tests_bless_yolo/revisions_bad.rs`
 
 error: aborting due to previous error
 

--- a/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/revisions_bad.foo.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/revisions_bad.foo.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/revisions_bad.rs:8:9
+ --> tests/actual_tests_bless_yolo/revisions_bad.rs:8:9
   |
 8 |     add("42", 3);
   |     --- ^^^^ expected `usize`, found `&str`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/rustfix-maybe-incorrect.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/rustfix-maybe-incorrect.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/rustfix-maybe-incorrect.rs:4:22
+ --> tests/actual_tests_bless_yolo/rustfix-maybe-incorrect.rs:4:22
   |
 4 |     let _x: String = 42;
   |             ------   ^^- help: try using a conversion method: `.to_string()`

--- a/tests/integrations/basic/tests/actual_tests/aux_derive.stderr
+++ b/tests/integrations/basic/tests/actual_tests/aux_derive.stderr
@@ -1,5 +1,5 @@
 warning: variable `x` is assigned to, but never used
- --> $DIR/aux_derive.rs:7:9
+ --> tests/actual_tests/aux_derive.rs:7:9
   |
 7 |     let x = Foo;
   |         ^
@@ -8,7 +8,7 @@ warning: variable `x` is assigned to, but never used
   = note: `#[warn(unused_variables)]` on by default
 
 warning: value assigned to `x` is never read
- --> $DIR/aux_derive.rs:8:5
+ --> tests/actual_tests/aux_derive.rs:8:5
   |
 8 |     x = Foo;
   |     ^
@@ -17,7 +17,7 @@ warning: value assigned to `x` is never read
   = note: `#[warn(unused_assignments)]` on by default
 
 error[E0384]: cannot assign twice to immutable variable `x`
- --> $DIR/aux_derive.rs:8:5
+ --> tests/actual_tests/aux_derive.rs:8:5
   |
 7 |     let x = Foo;
   |         -

--- a/tests/integrations/basic/tests/actual_tests/aux_proc_macro.stderr
+++ b/tests/integrations/basic/tests/actual_tests/aux_proc_macro.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `cake` in this scope
- --> $DIR/aux_proc_macro.rs:6:12
+ --> tests/actual_tests/aux_proc_macro.rs:6:12
   |
 6 |     thing!(cake);
   |            ^^^^ not found in this scope

--- a/tests/integrations/basic/tests/actual_tests/foomp-rustfix.stderr
+++ b/tests/integrations/basic/tests/actual_tests/foomp-rustfix.stderr
@@ -1,5 +1,5 @@
 error: variable does not need to be mutable
- --> $DIR/foomp-rustfix.rs:4:9
+ --> tests/actual_tests/foomp-rustfix.rs:4:9
   |
 4 |     let mut x = 42;
   |         ----^
@@ -7,7 +7,7 @@ error: variable does not need to be mutable
   |         help: remove this `mut`
   |
 note: the lint level is defined here
- --> $DIR/foomp-rustfix.rs:1:9
+ --> tests/actual_tests/foomp-rustfix.rs:1:9
   |
 1 | #![deny(warnings)]
   |         ^^^^^^^^

--- a/tests/integrations/basic/tests/actual_tests/foomp.stderr
+++ b/tests/integrations/basic/tests/actual_tests/foomp.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/foomp.rs:4:9
+ --> tests/actual_tests/foomp.rs:4:9
   |
 4 |     add("42", 3);
   |     --- ^^^^ expected `usize`, found `&str`

--- a/tests/integrations/basic/tests/actual_tests/no_rustfix.stderr
+++ b/tests/integrations/basic/tests/actual_tests/no_rustfix.stderr
@@ -1,5 +1,5 @@
 error: variable does not need to be mutable
- --> $DIR/no_rustfix.rs:6:9
+ --> tests/actual_tests/no_rustfix.rs:6:9
   |
 6 |     let mut x = 42;
   |         ----^
@@ -7,7 +7,7 @@ error: variable does not need to be mutable
   |         help: remove this `mut`
   |
 note: the lint level is defined here
- --> $DIR/no_rustfix.rs:3:9
+ --> tests/actual_tests/no_rustfix.rs:3:9
   |
 3 | #![deny(warnings)]
   |         ^^^^^^^^

--- a/tests/integrations/basic/tests/actual_tests/subdir/aux_proc_macro.stderr
+++ b/tests/integrations/basic/tests/actual_tests/subdir/aux_proc_macro.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `cake` in this scope
- --> $DIR/aux_proc_macro.rs:6:12
+ --> tests/actual_tests/subdir/aux_proc_macro.rs:6:12
   |
 6 |     thing!(cake);
   |            ^^^^ not found in this scope

--- a/tests/integrations/basic/tests/actual_tests/windows_paths.stderr
+++ b/tests/integrations/basic/tests/actual_tests/windows_paths.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/windows_paths.rs:2:9
+ --> tests/actual_tests/windows_paths.rs:2:9
   |
 2 |     let () = "escapes stay as backslashes: \t\r\n";
   |         ^^   ------------------------------------- this expression has type `&str`
@@ -7,7 +7,7 @@ error[E0308]: mismatched types
   |         expected `str`, found `()`
 
 error[E0308]: mismatched types
- --> $DIR/windows_paths.rs:5:9
+ --> tests/actual_tests/windows_paths.rs:5:9
   |
 5 |     let () = r"absolute: C:/foo/file.rs";
   |         ^^   --------------------------- this expression has type `&str`
@@ -15,7 +15,7 @@ error[E0308]: mismatched types
   |         expected `str`, found `()`
 
 error[E0308]: mismatched types
- --> $DIR/windows_paths.rs:7:9
+ --> tests/actual_tests/windows_paths.rs:7:9
   |
 7 |     let () = r"absolute, spaces: C:/foo bar/file.rs";
   |         ^^   --------------------------------------- this expression has type `&str`
@@ -23,7 +23,7 @@ error[E0308]: mismatched types
   |         expected `str`, found `()`
 
 error[E0308]: mismatched types
- --> $DIR/windows_paths.rs:9:9
+ --> tests/actual_tests/windows_paths.rs:9:9
   |
 9 |     let () = r"absolute, spaces, dir: C:/foo bar/some dir/";
   |         ^^   ---------------------------------------------- this expression has type `&str`
@@ -31,7 +31,7 @@ error[E0308]: mismatched types
   |         expected `str`, found `()`
 
 error[E0308]: mismatched types
-  --> $DIR/windows_paths.rs:11:9
+  --> tests/actual_tests/windows_paths.rs:11:9
    |
 11 |     let () = r"absolute, spaces, no extension: C:/foo bar/some file";
    |         ^^   ------------------------------------------------------- this expression has type `&str`
@@ -39,7 +39,7 @@ error[E0308]: mismatched types
    |         expected `str`, found `()`
 
 error[E0308]: mismatched types
-  --> $DIR/windows_paths.rs:14:9
+  --> tests/actual_tests/windows_paths.rs:14:9
    |
 14 |     let () = r"relative: foo/file.rs";
    |         ^^   ------------------------ this expression has type `&str`
@@ -47,7 +47,7 @@ error[E0308]: mismatched types
    |         expected `str`, found `()`
 
 error[E0308]: mismatched types
-  --> $DIR/windows_paths.rs:17:9
+  --> tests/actual_tests/windows_paths.rs:17:9
    |
 17 |     let () = r"unicode: Ryū/file.rs";
    |         ^^   ----------------------- this expression has type `&str`
@@ -55,7 +55,7 @@ error[E0308]: mismatched types
    |         expected `str`, found `()`
 
 error[E0308]: mismatched types
-  --> $DIR/windows_paths.rs:20:9
+  --> tests/actual_tests/windows_paths.rs:20:9
    |
 20 |     let () = r"mixed seperators: C:/foo/../bar/";
    |         ^^   ----------------------------------- this expression has type `&str`
@@ -63,7 +63,7 @@ error[E0308]: mismatched types
    |         expected `str`, found `()`
 
 error[E0308]: mismatched types
-  --> $DIR/windows_paths.rs:23:9
+  --> tests/actual_tests/windows_paths.rs:23:9
    |
 23 |     let () = r"unsupported: foo\bar";
    |         ^^   ----------------------- this expression has type `&str`


### PR DESCRIPTION
I've often wanted to ditch the `$DIR` replacement to make paths clickable in the terminal, this would allow that