### PR TITLE
Add option to set minimum "mandatory" message level

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
 use regex::bytes::Regex;
 
-use crate::{dependencies::build_dependencies, CommandBuilder, Filter, Match, Mode, RustfixMode};
+use crate::{
+    dependencies::build_dependencies, CommandBuilder, Filter, Level, Match, Mode, RustfixMode,
+};
 pub use color_eyre;
 use color_eyre::eyre::Result;
 use std::{
@@ -59,6 +61,9 @@ pub struct Config {
     pub run_only_ignored: bool,
     /// Filters must match exactly instead of just checking for substrings.
     pub filter_exact: bool,
+    /// If set, lower level annotations will still be checked but we won't go below
+    /// `forced_lowest_annotation_level`.
+    pub forced_lowest_annotation_level: Option<Level>,
 }
 
 impl Config {
@@ -103,6 +108,7 @@ impl Config {
             list: false,
             run_only_ignored: false,
             filter_exact: false,
+            forced_lowest_annotation_level: None,
         }
     }
 

--- a/src/rustc_stderr.rs
+++ b/src/rustc_stderr.rs
@@ -14,12 +14,18 @@ struct RustcMessage {
     children: Vec<RustcMessage>,
 }
 
+/// Message level.
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
-pub(crate) enum Level {
+pub enum Level {
+    /// Internal compiler error.
     Ice = 5,
+    /// Compilation error.
     Error = 4,
+    /// Compilation warning.
     Warn = 3,
+    /// Help message.
     Help = 2,
+    /// Note message.
     Note = 1,
     /// Only used for "For more information about this error, try `rustc --explain EXXXX`".
     FailureNote = 0,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -43,6 +43,7 @@ fn main() {
         &config,
         "",
         &comments,
+        None,
     )
     .unwrap();
     match &errors[..] {
@@ -81,6 +82,7 @@ fn main() {
             &config,
             "",
             &comments,
+            None,
         )
         .unwrap();
         match &errors[..] {
@@ -108,6 +110,7 @@ fn main() {
             &config,
             "",
             &comments,
+            None,
         )
         .unwrap();
         match &errors[..] {
@@ -139,6 +142,7 @@ fn main() {
             &config,
             "",
             &comments,
+            None,
         )
         .unwrap();
         match &errors[..] {
@@ -180,6 +184,7 @@ fn main() {
         &config,
         "",
         &comments,
+        None,
     )
     .unwrap();
     match &errors[..] {
@@ -223,6 +228,7 @@ fn main() {
         &config,
         "",
         &comments,
+        None,
     )
     .unwrap();
     match &errors[..] {
@@ -277,6 +283,7 @@ fn main() {
         &config,
         "",
         &comments,
+        None,
     )
     .unwrap();
     match &errors[..] {
@@ -341,6 +348,7 @@ fn main() {
         &config,
         "",
         &comments,
+        None,
     )
     .unwrap();
     match &errors[..] {


### PR DESCRIPTION
It is needed for clippy because we only want to set "error" message annotations as mandatory and not fail in case lower level are present in the file.

The reason is that currently, if a lower level message annotation is present, the "general level" of annotation becomes the lowest present in the test file, which is not something we want.

Needed for https://github.com/rust-lang/rust-clippy/pull/11421.