### PR TITLE
Base cfg printing off the program instead of allowing separate executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `Config::output_conflict_handling` does not contain the bless command message anymore, it is instead available separately as `Config::bless_command`
 * Updating `cargo_metadata` to `0.18`
 * Updated `spanned` to `0.1.5`, giving more precise spans for more iterator operations
+* `Config::cfgs` is now `Config::program::cfg_flag`
 
 ### Removed
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -20,6 +20,8 @@ pub struct CommandBuilder {
     /// Environment variables passed to the binary that is executed.
     /// The environment variable is removed if the second tuple field is `None`
     pub envs: Vec<(OsString, Option<OsString>)>,
+    /// A flag to add in order to make the command print the cfgs it supports
+    pub cfg_flag: Option<OsString>,
 }
 
 impl CommandBuilder {
@@ -31,6 +33,7 @@ impl CommandBuilder {
             out_dir_flag: Some("--target-dir".into()),
             input_file_flag: Some("--manifest-path".into()),
             envs: vec![],
+            cfg_flag: None,
         }
     }
 
@@ -45,14 +48,7 @@ impl CommandBuilder {
             out_dir_flag: Some("--out-dir".into()),
             input_file_flag: None,
             envs: vec![],
-        }
-    }
-
-    /// Same as [`CommandBuilder::rustc`], but with arguments for obtaining the cfgs.
-    pub fn cfgs() -> Self {
-        Self {
-            args: vec!["--print".into(), "cfg".into()],
-            ..Self::rustc()
+            cfg_flag: Some("--print=cfg".into()),
         }
     }
 
@@ -65,6 +61,7 @@ impl CommandBuilder {
             out_dir_flag: None,
             input_file_flag: None,
             envs: vec![],
+            cfg_flag: None,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,8 +27,6 @@ pub struct Config {
     pub root_dir: PathBuf,
     /// The binary to actually execute.
     pub program: CommandBuilder,
-    /// The command to run to obtain the cfgs that the output is supposed to
-    pub cfgs: CommandBuilder,
     /// What to do in case the stdout/stderr output differs from the expected one.
     pub output_conflict_handling: OutputConflictHandling,
     /// The recommended command to bless failing tests.
@@ -85,7 +83,6 @@ impl Config {
             target: None,
             root_dir: root_dir.into(),
             program: CommandBuilder::rustc(),
-            cfgs: CommandBuilder::cfgs(),
             output_conflict_handling: OutputConflictHandling::Bless,
             bless_command: None,
             dependencies_crate_manifest_path: None,

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -24,7 +24,11 @@ pub struct Dependencies {
 }
 
 fn cfgs(config: &Config) -> Result<Vec<Cfg>> {
-    let mut cmd = config.cfgs.build(&config.out_dir);
+    let Some(cfg) = &config.program.cfg_flag else {
+        return Ok(vec![]);
+    };
+    let mut cmd = config.program.build(&config.out_dir);
+    cmd.arg(cfg);
     cmd.arg("--target").arg(config.target.as_ref().unwrap());
     let output = cmd.output()?;
     let stdout = String::from_utf8(output.stdout)?;


### PR DESCRIPTION
fixes #185

# TODO (check if already done)
* [x] ~~Add tests~~ not necessary
* [x] Add CHANGELOG.md entry
