### PR TITLE
Allow error comments above the error site.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Fixedw
+* Add `//~v` comments to put an error matcher above the error site.
+
+### Fixed
 
 ### Changed
 

--- a/tests/integrations/basic-fail/Cargo.stdout
+++ b/tests/integrations/basic-fail/Cargo.stdout
@@ -12,6 +12,7 @@ tests/actual_tests/filters.rs ... FAILED
 tests/actual_tests/foomp.rs ... FAILED
 tests/actual_tests/foomp2.rs ... FAILED
 tests/actual_tests/pattern_too_many_arrow.rs ... FAILED
+tests/actual_tests/pattern_too_many_arrow_above.rs ... FAILED
 tests/actual_tests/rustc_ice.rs ... FAILED
 
 FAILED TEST: tests/actual_tests/bad_pattern.rs
@@ -268,6 +269,22 @@ full stdout:
 
 
 
+FAILED TEST: tests/actual_tests/pattern_too_many_arrow_above.rs
+command: "parse comments"
+
+error: //~v pattern is trying to refer to line 8, but the file only has 6 lines
+ --> tests/actual_tests/pattern_too_many_arrow_above.rs:2:22
+  |
+2 |     //~vvvvvv ERROR: mismatched types
+  |                      ^^^^^^^^^^^^^^^^
+  |
+
+full stderr:
+
+full stdout:
+
+
+
 FAILED TEST: tests/actual_tests/rustc_ice.rs
 command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/rustc_ice.rs" "-Ztreat-err-as-bug" "--edition" "2021"
 
@@ -323,9 +340,10 @@ FAILURES:
     tests/actual_tests/foomp.rs
     tests/actual_tests/foomp2.rs
     tests/actual_tests/pattern_too_many_arrow.rs
+    tests/actual_tests/pattern_too_many_arrow_above.rs
     tests/actual_tests/rustc_ice.rs
 
-test result: FAIL. 9 failed;
+test result: FAIL. 10 failed;
 
 Building dependencies ... ok
 tests/actual_tests_bless/aux_build_not_found.rs ... FAILED
@@ -914,6 +932,7 @@ tests/actual_tests/filters.rs ... FAILED
 tests/actual_tests/foomp.rs ... FAILED
 tests/actual_tests/foomp2.rs ... FAILED
 tests/actual_tests/pattern_too_many_arrow.rs ... FAILED
+tests/actual_tests/pattern_too_many_arrow_above.rs ... FAILED
 tests/actual_tests/rustc_ice.rs ... FAILED
 
 FAILED TEST: tests/actual_tests/bad_pattern.rs
@@ -1002,6 +1021,22 @@ full stdout:
 
 
 
+FAILED TEST: tests/actual_tests/pattern_too_many_arrow_above.rs
+command: "parse comments"
+
+error: //~v pattern is trying to refer to line 8, but the file only has 6 lines
+ --> tests/actual_tests/pattern_too_many_arrow_above.rs:2:22
+  |
+2 |     //~vvvvvv ERROR: mismatched types
+  |                      ^^^^^^^^^^^^^^^^
+  |
+
+full stderr:
+
+full stdout:
+
+
+
 FAILED TEST: tests/actual_tests/rustc_ice.rs
 command: "$CMD" "tests/actual_tests/rustc_ice.rs" "-Ztreat-err-as-bug" "--edition" "2021"
 
@@ -1019,9 +1054,10 @@ FAILURES:
     tests/actual_tests/foomp.rs
     tests/actual_tests/foomp2.rs
     tests/actual_tests/pattern_too_many_arrow.rs
+    tests/actual_tests/pattern_too_many_arrow_above.rs
     tests/actual_tests/rustc_ice.rs
 
-test result: FAIL. 9 failed;
+test result: FAIL. 10 failed;
 
 
 running 0 tests

--- a/tests/integrations/basic-fail/tests/actual_tests/pattern_too_many_arrow_above.rs
+++ b/tests/integrations/basic-fail/tests/actual_tests/pattern_too_many_arrow_above.rs
@@ -1,0 +1,6 @@
+fn main() {
+    //~vvvvvv ERROR: mismatched types
+    use_unit(1_u32);
+}
+
+fn use_unit(_: ()) {}

--- a/tests/integrations/basic/Cargo.stdout
+++ b/tests/integrations/basic/Cargo.stdout
@@ -13,6 +13,7 @@ Building aux file tests/actual_tests/auxiliary/derive_proc_macro.rs ... ok
 tests/actual_tests/aux_derive.rs ... ok
 Building aux file tests/actual_tests/auxiliary/the_proc_macro.rs ... ok
 tests/actual_tests/aux_proc_macro.rs ... ok
+tests/actual_tests/error_above.rs ... ok
 tests/actual_tests/executable.rs ... ok
 tests/actual_tests/foomp-rustfix.rs ... ok
 tests/actual_tests/foomp.rs ... ok
@@ -23,7 +24,7 @@ tests/actual_tests/unicode.rs ... ok
 tests/actual_tests/windows_paths.rs ... ok
 tests/actual_tests/subdir/aux_proc_macro.rs ... ok
 
-test result: ok. 11 passed;
+test result: ok. 12 passed;
 
 
 running 0 tests

--- a/tests/integrations/basic/tests/actual_tests/error_above.rs
+++ b/tests/integrations/basic/tests/actual_tests/error_above.rs
@@ -1,0 +1,6 @@
+use basic::add;
+
+fn main() {
+    //~v ERROR: mismatched types
+    add("42", 3);
+}

--- a/tests/integrations/basic/tests/actual_tests/error_above.stderr
+++ b/tests/integrations/basic/tests/actual_tests/error_above.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+ --> tests/actual_tests/error_above.rs:5:9
+  |
+5 |     add("42", 3);
+  |     --- ^^^^ expected `usize`, found `&str`
+  |     |
+  |     arguments to this function are incorrect
+  |
+note: function defined here
+ --> $DIR/tests/integrations/basic/src/lib.rs:1:8
+  |
+1 | pub fn add(left: usize, right: usize) -> usize {
+  |        ^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Clippy has some lints which take comments into account and where the error span encompasses multiple lines. Currently this requires putting the matcher many lines later and then counting the lines. e.g.

```rust
if foo {
  foo;
  bar;
  baz;
} else {
  foo;
  bar;
  baz;
} 
//~^^^^^^^^^ ERROR: same if else bodies
```

This patch allows putting the matcher above, avoiding the problem.

```rust
//~v ERROR: same if else bodies
if foo {
  foo;
  bar;
  baz;
} else {
  foo;
  bar;
  baz;
} 
```