### PR TITLE
Allow `//~|` comments to preceed `//~v` comments.

### DIFF
--- a/tests/integrations/basic-fail/Cargo.stdout
+++ b/tests/integrations/basic-fail/Cargo.stdout
@@ -11,9 +11,14 @@ tests/actual_tests/exit_code_fail.rs ... FAILED
 tests/actual_tests/filters.rs ... FAILED
 tests/actual_tests/foomp.rs ... FAILED
 tests/actual_tests/foomp2.rs ... FAILED
+tests/actual_tests/inline_chain.rs ... FAILED
+tests/actual_tests/joined_wrong_order.rs ... FAILED
+tests/actual_tests/lone_joined_pattern.rs ... FAILED
 tests/actual_tests/pattern_too_many_arrow.rs ... FAILED
 tests/actual_tests/pattern_too_many_arrow_above.rs ... FAILED
 tests/actual_tests/rustc_ice.rs ... FAILED
+tests/actual_tests/touching_above_below.rs ... FAILED
+tests/actual_tests/touching_above_below_chain.rs ... FAILED
 
 FAILED TEST: tests/actual_tests/bad_pattern.rs
 command: "rustc" "--error-format=json" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests/bad_pattern.rs" "--edition" "2021"
@@ -253,6 +258,61 @@ full stdout:
 
 
 
+FAILED TEST: tests/actual_tests/inline_chain.rs
+command: "parse comments"
+
+error: `//~|` comment not attached to anchoring matcher
+ --> tests/actual_tests/inline_chain.rs:5:26
+  |
+5 |                       //~| unused_variables
+  |                          ^
+  |
+
+full stderr:
+
+full stdout:
+
+
+
+FAILED TEST: tests/actual_tests/joined_wrong_order.rs
+command: "parse comments"
+
+error: `//~|` comment not attached to anchoring matcher
+ --> tests/actual_tests/joined_wrong_order.rs:5:8
+  |
+5 |     //~| unused_mut
+  |        ^
+  |
+
+full stderr:
+
+full stdout:
+
+
+
+FAILED TEST: tests/actual_tests/lone_joined_pattern.rs
+command: "parse comments"
+
+error: `//~|` comment not attached to anchoring matcher
+ --> tests/actual_tests/lone_joined_pattern.rs:2:8
+  |
+2 |     //~| ERROR: mismatched types
+  |        ^
+  |
+
+error: `//~|` comment not attached to anchoring matcher
+ --> tests/actual_tests/lone_joined_pattern.rs:4:8
+  |
+4 |     //~| ERROR: mismatched types
+  |        ^
+  |
+
+full stderr:
+
+full stdout:
+
+
+
 FAILED TEST: tests/actual_tests/pattern_too_many_arrow.rs
 command: "parse comments"
 
@@ -331,6 +391,38 @@ end of query stack
 full stdout:
 
 
+
+FAILED TEST: tests/actual_tests/touching_above_below.rs
+command: "parse comments"
+
+error: `//~v` comment immediately following a `//~^` comment chain
+ --> tests/actual_tests/touching_above_below.rs:4:8
+  |
+4 |     //~v ERROR: mismatched types
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+
+full stderr:
+
+full stdout:
+
+
+
+FAILED TEST: tests/actual_tests/touching_above_below_chain.rs
+command: "parse comments"
+
+error: `//~v` comment immediately following a `//~^` comment chain
+ --> tests/actual_tests/touching_above_below_chain.rs:5:8
+  |
+5 |     //~v ERROR: unused variable
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+
+full stderr:
+
+full stdout:
+
+
 FAILURES:
     tests/actual_tests/bad_pattern.rs
     tests/actual_tests/executable.rs
@@ -339,11 +431,16 @@ FAILURES:
     tests/actual_tests/filters.rs
     tests/actual_tests/foomp.rs
     tests/actual_tests/foomp2.rs
+    tests/actual_tests/inline_chain.rs
+    tests/actual_tests/joined_wrong_order.rs
+    tests/actual_tests/lone_joined_pattern.rs
     tests/actual_tests/pattern_too_many_arrow.rs
     tests/actual_tests/pattern_too_many_arrow_above.rs
     tests/actual_tests/rustc_ice.rs
+    tests/actual_tests/touching_above_below.rs
+    tests/actual_tests/touching_above_below_chain.rs
 
-test result: FAIL. 10 failed;
+test result: FAIL. 15 failed;
 
 Building dependencies ... ok
 tests/actual_tests_bless/aux_build_not_found.rs ... FAILED
@@ -931,9 +1028,14 @@ tests/actual_tests/exit_code_fail.rs ... FAILED
 tests/actual_tests/filters.rs ... FAILED
 tests/actual_tests/foomp.rs ... FAILED
 tests/actual_tests/foomp2.rs ... FAILED
+tests/actual_tests/inline_chain.rs ... FAILED
+tests/actual_tests/joined_wrong_order.rs ... FAILED
+tests/actual_tests/lone_joined_pattern.rs ... FAILED
 tests/actual_tests/pattern_too_many_arrow.rs ... FAILED
 tests/actual_tests/pattern_too_many_arrow_above.rs ... FAILED
 tests/actual_tests/rustc_ice.rs ... FAILED
+tests/actual_tests/touching_above_below.rs ... FAILED
+tests/actual_tests/touching_above_below_chain.rs ... FAILED
 
 FAILED TEST: tests/actual_tests/bad_pattern.rs
 command: "$CMD" "tests/actual_tests/bad_pattern.rs" "--edition" "2021"
@@ -1005,6 +1107,61 @@ full stdout:
 could not spawn `"invalid_foobarlaksdfalsdfj"` as a process
 
 
+FAILED TEST: tests/actual_tests/inline_chain.rs
+command: "parse comments"
+
+error: `//~|` comment not attached to anchoring matcher
+ --> tests/actual_tests/inline_chain.rs:5:26
+  |
+5 |                       //~| unused_variables
+  |                          ^
+  |
+
+full stderr:
+
+full stdout:
+
+
+
+FAILED TEST: tests/actual_tests/joined_wrong_order.rs
+command: "parse comments"
+
+error: `//~|` comment not attached to anchoring matcher
+ --> tests/actual_tests/joined_wrong_order.rs:5:8
+  |
+5 |     //~| unused_mut
+  |        ^
+  |
+
+full stderr:
+
+full stdout:
+
+
+
+FAILED TEST: tests/actual_tests/lone_joined_pattern.rs
+command: "parse comments"
+
+error: `//~|` comment not attached to anchoring matcher
+ --> tests/actual_tests/lone_joined_pattern.rs:2:8
+  |
+2 |     //~| ERROR: mismatched types
+  |        ^
+  |
+
+error: `//~|` comment not attached to anchoring matcher
+ --> tests/actual_tests/lone_joined_pattern.rs:4:8
+  |
+4 |     //~| ERROR: mismatched types
+  |        ^
+  |
+
+full stderr:
+
+full stdout:
+
+
+
 FAILED TEST: tests/actual_tests/pattern_too_many_arrow.rs
 command: "parse comments"
 
@@ -1045,6 +1202,38 @@ No such file or directory
 full stdout:
 could not spawn `"invalid_foobarlaksdfalsdfj"` as a process
 
+
+FAILED TEST: tests/actual_tests/touching_above_below.rs
+command: "parse comments"
+
+error: `//~v` comment immediately following a `//~^` comment chain
+ --> tests/actual_tests/touching_above_below.rs:4:8
+  |
+4 |     //~v ERROR: mismatched types
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+
+full stderr:
+
+full stdout:
+
+
+
+FAILED TEST: tests/actual_tests/touching_above_below_chain.rs
+command: "parse comments"
+
+error: `//~v` comment immediately following a `//~^` comment chain
+ --> tests/actual_tests/touching_above_below_chain.rs:5:8
+  |
+5 |     //~v ERROR: unused variable
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+
+full stderr:
+
+full stdout:
+
+
 FAILURES:
     tests/actual_tests/bad_pattern.rs
     tests/actual_tests/executable.rs
@@ -1053,11 +1242,16 @@ FAILURES:
     tests/actual_tests/filters.rs
     tests/actual_tests/foomp.rs
     tests/actual_tests/foomp2.rs
+    tests/actual_tests/inline_chain.rs
+    tests/actual_tests/joined_wrong_order.rs
+    tests/actual_tests/lone_joined_pattern.rs
     tests/actual_tests/pattern_too_many_arrow.rs
     tests/actual_tests/pattern_too_many_arrow_above.rs
     tests/actual_tests/rustc_ice.rs
+    tests/actual_tests/touching_above_below.rs
+    tests/actual_tests/touching_above_below_chain.rs
 
-test result: FAIL. 10 failed;
+test result: FAIL. 15 failed;
 
 
 running 0 tests

--- a/tests/integrations/basic-fail/tests/actual_tests/inline_chain.rs
+++ b/tests/integrations/basic-fail/tests/actual_tests/inline_chain.rs
@@ -1,0 +1,6 @@
+#![deny(unused_mut, unused_variables)]
+
+fn main() {
+    let mut x = 0u32; //~ unused_mut
+                      //~| unused_variables
+}

--- a/tests/integrations/basic-fail/tests/actual_tests/joined_wrong_order.rs
+++ b/tests/integrations/basic-fail/tests/actual_tests/joined_wrong_order.rs
@@ -1,0 +1,7 @@
+#![deny(unused_mut, unused_variables)]
+
+fn main() {
+    //~vv unused_variables
+    //~| unused_mut
+    let mut x = 0u32;
+}

--- a/tests/integrations/basic-fail/tests/actual_tests/lone_joined_pattern.rs
+++ b/tests/integrations/basic-fail/tests/actual_tests/lone_joined_pattern.rs
@@ -1,0 +1,7 @@
+fn main() {
+    //~| ERROR: mismatched types
+    use_unit(1_u32);
+    //~| ERROR: mismatched types
+}
+
+fn use_unit(_: ()) {}

--- a/tests/integrations/basic-fail/tests/actual_tests/touching_above_below.rs
+++ b/tests/integrations/basic-fail/tests/actual_tests/touching_above_below.rs
@@ -1,0 +1,8 @@
+fn main() {
+    use_unit(1_u32);
+    //~^ ERROR: mismatched types
+    //~v ERROR: mismatched types
+    use_unit(1_u32);
+}
+
+fn use_unit(_: ()) {}

--- a/tests/integrations/basic-fail/tests/actual_tests/touching_above_below_chain.rs
+++ b/tests/integrations/basic-fail/tests/actual_tests/touching_above_below_chain.rs
@@ -1,0 +1,9 @@
+fn main() {
+    use_unit(1_u32);
+    //~^ ERROR: mismatched types
+    //~| ERROR: variable does not need to be mutable
+    //~v ERROR: unused variable
+    let mut x = 0u32;
+}
+
+fn use_unit(_: ()) {}

--- a/tests/integrations/basic/Cargo.stdout
+++ b/tests/integrations/basic/Cargo.stdout
@@ -17,6 +17,9 @@ tests/actual_tests/error_above.rs ... ok
 tests/actual_tests/executable.rs ... ok
 tests/actual_tests/foomp-rustfix.rs ... ok
 tests/actual_tests/foomp.rs ... ok
+tests/actual_tests/joined_above.rs ... ok
+tests/actual_tests/joined_below.rs ... ok
+tests/actual_tests/joined_mixed.rs ... ok
 tests/actual_tests/match_diagnostic_code.rs ... ok
 tests/actual_tests/no_rustfix.rs ... ok
 tests/actual_tests/stdin.rs ... ok
@@ -24,7 +27,7 @@ tests/actual_tests/unicode.rs ... ok
 tests/actual_tests/windows_paths.rs ... ok
 tests/actual_tests/subdir/aux_proc_macro.rs ... ok
 
-test result: ok. 12 passed;
+test result: ok. 15 passed;
 
 
 running 0 tests

--- a/tests/integrations/basic/tests/actual_tests/joined_above.fixed
+++ b/tests/integrations/basic/tests/actual_tests/joined_above.fixed
@@ -1,0 +1,7 @@
+#![deny(unused_mut, unused_variables)]
+
+fn main() {
+    //~| unused_mut
+    //~v unused_variables
+    let _x = 0u32;
+}

--- a/tests/integrations/basic/tests/actual_tests/joined_above.rs
+++ b/tests/integrations/basic/tests/actual_tests/joined_above.rs
@@ -1,0 +1,7 @@
+#![deny(unused_mut, unused_variables)]
+
+fn main() {
+    //~| unused_mut
+    //~v unused_variables
+    let mut x = 0u32;
+}

--- a/tests/integrations/basic/tests/actual_tests/joined_above.stderr
+++ b/tests/integrations/basic/tests/actual_tests/joined_above.stderr
@@ -1,0 +1,28 @@
+error: unused variable: `x`
+ --> tests/actual_tests/joined_above.rs:6:13
+  |
+6 |     let mut x = 0u32;
+  |             ^ help: if this is intentional, prefix it with an underscore: `_x`
+  |
+note: the lint level is defined here
+ --> tests/actual_tests/joined_above.rs:1:21
+  |
+1 | #![deny(unused_mut, unused_variables)]
+  |                     ^^^^^^^^^^^^^^^^
+
+error: variable does not need to be mutable
+ --> tests/actual_tests/joined_above.rs:6:9
+  |
+6 |     let mut x = 0u32;
+  |         ----^
+  |         |
+  |         help: remove this `mut`
+  |
+note: the lint level is defined here
+ --> tests/actual_tests/joined_above.rs:1:9
+  |
+1 | #![deny(unused_mut, unused_variables)]
+  |         ^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/integrations/basic/tests/actual_tests/joined_below.fixed
+++ b/tests/integrations/basic/tests/actual_tests/joined_below.fixed
@@ -1,0 +1,7 @@
+#![deny(unused_mut, unused_variables)]
+
+fn main() {
+    let _x = 0u32;
+    //~^ unused_variables
+    //~| unused_mut
+}

--- a/tests/integrations/basic/tests/actual_tests/joined_below.rs
+++ b/tests/integrations/basic/tests/actual_tests/joined_below.rs
@@ -1,0 +1,7 @@
+#![deny(unused_mut, unused_variables)]
+
+fn main() {
+    let mut x = 0u32;
+    //~^ unused_variables
+    //~| unused_mut
+}

--- a/tests/integrations/basic/tests/actual_tests/joined_below.stderr
+++ b/tests/integrations/basic/tests/actual_tests/joined_below.stderr
@@ -1,0 +1,28 @@
+error: unused variable: `x`
+ --> tests/actual_tests/joined_below.rs:4:13
+  |
+4 |     let mut x = 0u32;
+  |             ^ help: if this is intentional, prefix it with an underscore: `_x`
+  |
+note: the lint level is defined here
+ --> tests/actual_tests/joined_below.rs:1:21
+  |
+1 | #![deny(unused_mut, unused_variables)]
+  |                     ^^^^^^^^^^^^^^^^
+
+error: variable does not need to be mutable
+ --> tests/actual_tests/joined_below.rs:4:9
+  |
+4 |     let mut x = 0u32;
+  |         ----^
+  |         |
+  |         help: remove this `mut`
+  |
+note: the lint level is defined here
+ --> tests/actual_tests/joined_below.rs:1:9
+  |
+1 | #![deny(unused_mut, unused_variables)]
+  |         ^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/integrations/basic/tests/actual_tests/joined_mixed.fixed
+++ b/tests/integrations/basic/tests/actual_tests/joined_mixed.fixed
@@ -1,0 +1,11 @@
+#![deny(unused_mut, unused_variables)]
+
+fn main() {
+    let _x = 0u32;
+    //~^ unused_variables
+    //~| unused_mut
+
+    //~| unused_mut
+    //~v unused_variables
+    let _y = 0u32;
+}

--- a/tests/integrations/basic/tests/actual_tests/joined_mixed.rs
+++ b/tests/integrations/basic/tests/actual_tests/joined_mixed.rs
@@ -1,0 +1,11 @@
+#![deny(unused_mut, unused_variables)]
+
+fn main() {
+    let mut x = 0u32;
+    //~^ unused_variables
+    //~| unused_mut
+
+    //~| unused_mut
+    //~v unused_variables
+    let mut y = 0u32;
+}

--- a/tests/integrations/basic/tests/actual_tests/joined_mixed.stderr
+++ b/tests/integrations/basic/tests/actual_tests/joined_mixed.stderr
@@ -1,0 +1,42 @@
+error: unused variable: `x`
+ --> tests/actual_tests/joined_mixed.rs:4:13
+  |
+4 |     let mut x = 0u32;
+  |             ^ help: if this is intentional, prefix it with an underscore: `_x`
+  |
+note: the lint level is defined here
+ --> tests/actual_tests/joined_mixed.rs:1:21
+  |
+1 | #![deny(unused_mut, unused_variables)]
+  |                     ^^^^^^^^^^^^^^^^
+
+error: unused variable: `y`
+  --> tests/actual_tests/joined_mixed.rs:10:13
+   |
+10 |     let mut y = 0u32;
+   |             ^ help: if this is intentional, prefix it with an underscore: `_y`
+
+error: variable does not need to be mutable
+ --> tests/actual_tests/joined_mixed.rs:4:9
+  |
+4 |     let mut x = 0u32;
+  |         ----^
+  |         |
+  |         help: remove this `mut`
+  |
+note: the lint level is defined here
+ --> tests/actual_tests/joined_mixed.rs:1:9
+  |
+1 | #![deny(unused_mut, unused_variables)]
+  |         ^^^^^^^^^^
+
+error: variable does not need to be mutable
+  --> tests/actual_tests/joined_mixed.rs:10:9
+   |
+10 |     let mut y = 0u32;
+   |         ----^
+   |         |
+   |         help: remove this `mut`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Fixes an oversight from when `//~v` comments were added. Current implementation flips the order required which wouldn't be backwards compatible. Supporting stacking both above and below would be trivial if you'd prefer.

This should probably error when it's ambiguous which arrow to follow, though it currently binds above in such a case. e.g.

```rust
//~^ error
//~| error2 
//~v error3
```