### PR TITLE
Don't let non-primary spans take priority over primary spans.

### DIFF
--- a/src/rustc_stderr.rs
+++ b/src/rustc_stderr.rs
@@ -144,8 +144,14 @@ impl RustcSpan {
     /// Returns the most expanded line number *in the given file*, if possible.
     fn line(&self, file: &Path, primary: bool) -> Option<spanned::Span> {
         if let Some(exp) = &self.expansion {
-            if let Some(line) = exp.span.line(file, primary && !self.is_primary) {
+            if let Some(line) = exp.span.line(file, !primary || self.is_primary) {
                 return Some(line);
+            } else if self.file_name != file {
+                return if !primary && self.is_primary {
+                    exp.span.line(file, false)
+                } else {
+                    None
+                };
             }
         }
         ((!primary || self.is_primary) && self.file_name == file).then_some(spanned::Span {

--- a/tests/integrations/basic/Cargo.stdout
+++ b/tests/integrations/basic/Cargo.stdout
@@ -20,6 +20,7 @@ tests/actual_tests/foomp.rs ... ok
 tests/actual_tests/joined_above.rs ... ok
 tests/actual_tests/joined_below.rs ... ok
 tests/actual_tests/joined_mixed.rs ... ok
+tests/actual_tests/mac_span.rs ... ok
 tests/actual_tests/match_diagnostic_code.rs ... ok
 tests/actual_tests/no_rustfix.rs ... ok
 tests/actual_tests/stdin.rs ... ok
@@ -27,7 +28,7 @@ tests/actual_tests/unicode.rs ... ok
 tests/actual_tests/windows_paths.rs ... ok
 tests/actual_tests/subdir/aux_proc_macro.rs ... ok
 
-test result: ok. 15 passed;
+test result: ok. 16 passed;
 
 
 running 0 tests

--- a/tests/integrations/basic/tests/actual_tests/mac_span.fixed
+++ b/tests/integrations/basic/tests/actual_tests/mac_span.fixed
@@ -1,0 +1,11 @@
+#![deny(unused_variables)]
+
+macro_rules! m {
+    () => {{
+        let _x = 0; //~ unused_variables
+    }};
+}
+
+fn main() {
+    m!();
+}

--- a/tests/integrations/basic/tests/actual_tests/mac_span.rs
+++ b/tests/integrations/basic/tests/actual_tests/mac_span.rs
@@ -1,0 +1,11 @@
+#![deny(unused_variables)]
+
+macro_rules! m {
+    () => {{
+        let x = 0; //~ unused_variables
+    }};
+}
+
+fn main() {
+    m!();
+}

--- a/tests/integrations/basic/tests/actual_tests/mac_span.stderr
+++ b/tests/integrations/basic/tests/actual_tests/mac_span.stderr
@@ -1,0 +1,18 @@
+error: unused variable: `x`
+  --> tests/actual_tests/mac_span.rs:5:13
+   |
+5  |         let x = 0;
+   |             ^ help: if this is intentional, prefix it with an underscore: `_x`
+...
+10 |     m!();
+   |     ---- in this macro invocation
+   |
+note: the lint level is defined here
+  --> tests/actual_tests/mac_span.rs:1:9
+   |
+1  | #![deny(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Came up while converting clippy to use annotations.