### PR TITLE
Fix docs for `{ignore,only}-target-*` directive differences with compiletest

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ their command specifies, or the test will fail without even being run.
 
 ## Significant differences to compiletest-rs
 
-* `ignore-target-*` and `only-target-*` operate solely on the triple, instead of supporting things like `macos`
+* `ignore-target-xxx` and `only-target-xxx` requires the `target-` prefix before the `xxx` substring
+  to be matched against target triples, whereas compiletest allows plain `ignore-xxx` without the
+  `target-` prefix.
 * only supports `ui` tests
 * tests are run in named order, so you can prefix slow tests with `0` in order to make them get run first
 * `aux-build`s require specifying nested aux builds explicitly and will not allow you to reference sibling `aux-build`s' artifacts.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ their command specifies, or the test will fail without even being run.
 
 * `ignore-target-xxx` and `only-target-xxx` requires the `target-` prefix before the `xxx` substring
   to be matched against target triples, whereas compiletest allows plain `ignore-xxx` without the
-  `target-` prefix.
+  `target-` prefix. The substring `xxx` must also be a substring of target triples, and special
+  collections such as `macos`/`unix` in compiletest is not supported.
 * only supports `ui` tests
 * tests are run in named order, so you can prefix slow tests with `0` in order to make them get run first
 * `aux-build`s require specifying nested aux builds explicitly and will not allow you to reference sibling `aux-build`s' artifacts.


### PR DESCRIPTION
`ignore-target-*` and `only-target-*` does not, in fact, "operate solely on the triple, instead of supporting things like `macos`". It actually supports things like `macos` AFAICT because ui_test seems to match the `*` as a substring of target triples.