### PR TITLE
separate run and rustfix modes into their own modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * replaced `Mode::Run` with a rustc-specific run flag
 * replaced rustfix with a rustc-specific rustfix flag
 * replaced `rustfix` fields of `Mode::Fail` and `Mode::Yolo` by instead overwriting the rustc-specific custom flag
+* aux builds and dependencies are now built *per* `Config` instead of being built just for the first `Config` and the result shared by the others
+    * the configs could be different enough that aux builds built with a different config are incompatible (e.g. different targets).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `Config::custom_comments`
 * `Revisioned::custom`
+* `Flag` trait for custom `//@` flags
+* `Build` trait for custom aux/dep build
+    * `BuildManager` for deduplicating these builds on a per-`Config` basis
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * replaced `rustfix` fields of `Mode::Fail` and `Mode::Yolo` by instead overwriting the rustc-specific custom flag
 * aux builds and dependencies are now built *per* `Config` instead of being built just for the first `Config` and the result shared by the others
     * the configs could be different enough that aux builds built with a different config are incompatible (e.g. different targets).
+* replaced `Revisioned::aux_builds` with a rustc-specific custom flag
 
 ### Removed
 

--- a/src/aux_builds.rs
+++ b/src/aux_builds.rs
@@ -1,0 +1,100 @@
+//! Everything needed to build auxilary files with rustc
+// lol we can't name this file `aux.rs` on windows
+
+use bstr::ByteSlice;
+use std::{ffi::OsString, path::PathBuf, process::Command};
+
+use crate::{
+    default_per_file_config,
+    dependencies::{Build, BuildManager},
+    per_test_config::{Comments, TestConfig},
+    rustc_stderr, CrateType, Error, Errored,
+};
+
+/// Build an aux-build.
+pub struct AuxBuilder {
+    /// Full path to the file (including `auxiliary` folder prefix)
+    pub aux_file: PathBuf,
+}
+
+impl Build for AuxBuilder {
+    fn build(&self, build_manager: &BuildManager<'_>) -> Result<Vec<OsString>, Errored> {
+        let mut config = build_manager.config().clone();
+        let file_contents = std::fs::read(&self.aux_file).map_err(|err| Errored {
+            command: Command::new(format!("reading aux file `{}`", self.aux_file.display())),
+            errors: vec![],
+            stderr: err.to_string().into_bytes(),
+            stdout: vec![],
+        })?;
+        let comments = Comments::parse(&file_contents, &config, &self.aux_file)
+            .map_err(|errors| Errored::new(errors, "parse aux comments"))?;
+        assert_eq!(
+            comments.revisions, None,
+            "aux builds cannot specify revisions"
+        );
+
+        default_per_file_config(&mut config, &self.aux_file, &file_contents);
+
+        match CrateType::from_file_contents(&file_contents) {
+            // Proc macros must be run on the host
+            CrateType::ProcMacro => config.target = config.host.clone(),
+            CrateType::Test | CrateType::Bin | CrateType::Lib => {}
+        }
+
+        let mut config = TestConfig {
+            config,
+            revision: "",
+            comments: &comments,
+            path: &self.aux_file,
+        };
+
+        config.patch_out_dir();
+
+        let mut aux_cmd = config.build_command()?;
+
+        let mut extra_args =
+            config.build_aux_files(self.aux_file.parent().unwrap(), build_manager)?;
+        // Make sure we see our dependencies
+        aux_cmd.args(extra_args.iter());
+
+        aux_cmd.arg("--emit=link");
+        let filename = self.aux_file.file_stem().unwrap().to_str().unwrap();
+        let output = aux_cmd.output().unwrap();
+        if !output.status.success() {
+            let error = Error::Command {
+                kind: "compilation of aux build failed".to_string(),
+                status: output.status,
+            };
+            return Err(Errored {
+                command: aux_cmd,
+                errors: vec![error],
+                stderr: rustc_stderr::process(&self.aux_file, &output.stderr).rendered,
+                stdout: output.stdout,
+            });
+        }
+
+        // Now run the command again to fetch the output filenames
+        aux_cmd.arg("--print").arg("file-names");
+        let output = aux_cmd.output().unwrap();
+        assert!(output.status.success());
+
+        for file in output.stdout.lines() {
+            let file = std::str::from_utf8(file).unwrap();
+            let crate_name = filename.replace('-', "_");
+            let path = config.config.out_dir.join(file);
+            extra_args.push("--extern".into());
+            let mut cname = OsString::from(&crate_name);
+            cname.push("=");
+            cname.push(path);
+            extra_args.push(cname);
+            // Help cargo find the crates added with `--extern`.
+            extra_args.push("-L".into());
+            extra_args.push(config.config.out_dir.as_os_str().to_os_string());
+        }
+        Ok(extra_args)
+    }
+
+    fn description(&self) -> String {
+        format!("Building aux file {}", self.aux_file.display())
+    }
+}

--- a/src/aux_builds.rs
+++ b/src/aux_builds.rs
@@ -5,8 +5,8 @@ use bstr::ByteSlice;
 use std::{ffi::OsString, path::PathBuf, process::Command};
 
 use crate::{
+    build_manager::{Build, BuildManager},
     default_per_file_config,
-    dependencies::{Build, BuildManager},
     per_test_config::{Comments, TestConfig},
     rustc_stderr, CrateType, Error, Errored,
 };

--- a/src/aux_builds.rs
+++ b/src/aux_builds.rs
@@ -46,11 +46,12 @@ impl Build for AuxBuilder {
             revision: "",
             comments: &comments,
             path: &self.aux_file,
+            aux_dir: self.aux_file.parent().unwrap(),
         };
 
         config.patch_out_dir();
 
-        let mut aux_cmd = config.build_command()?;
+        let mut aux_cmd = config.build_command(build_manager)?;
 
         let mut extra_args =
             config.build_aux_files(self.aux_file.parent().unwrap(), build_manager)?;

--- a/src/aux_builds.rs
+++ b/src/aux_builds.rs
@@ -23,54 +23,50 @@ impl Flag for AuxBuilder {
         config: &TestConfig<'_>,
         build_manager: &BuildManager<'_>,
     ) -> Result<(), Errored> {
-        let mut extra_args = vec![];
         let aux = &self.aux_file;
         let aux_dir = config.aux_dir;
-        let extra_args: &mut Vec<OsString> = &mut extra_args;
         let line = aux.line();
         let aux_file = if aux.starts_with("..") {
             aux_dir.parent().unwrap().join(&aux.content)
         } else {
             aux_dir.join(&aux.content)
         };
-        extra_args.extend(
-            build_manager
-                .build(AuxBuilder {
-                    aux_file: Spanned::new(
-                        crate::core::strip_path_prefix(
-                            &aux_file.canonicalize().map_err(|err| Errored {
-                                command: Command::new(format!(
-                                    "canonicalizing path `{}`",
-                                    aux_file.display()
-                                )),
-                                errors: vec![],
-                                stderr: err.to_string().into_bytes(),
-                                stdout: vec![],
-                            })?,
-                            &std::env::current_dir().unwrap(),
-                        )
-                        .collect(),
-                        aux.span(),
-                    ),
-                })
-                .map_err(
-                    |Errored {
-                         command,
-                         errors,
-                         stderr,
-                         stdout,
-                     }| Errored {
-                        command,
-                        errors: vec![Error::Aux {
-                            path: aux_file.to_path_buf(),
-                            errors,
-                            line,
-                        }],
-                        stderr,
-                        stdout,
-                    },
-                )?,
-        );
+        let extra_args = build_manager
+            .build(AuxBuilder {
+                aux_file: Spanned::new(
+                    crate::core::strip_path_prefix(
+                        &aux_file.canonicalize().map_err(|err| Errored {
+                            command: Command::new(format!(
+                                "canonicalizing path `{}`",
+                                aux_file.display()
+                            )),
+                            errors: vec![],
+                            stderr: err.to_string().into_bytes(),
+                            stdout: vec![],
+                        })?,
+                        &std::env::current_dir().unwrap(),
+                    )
+                    .collect(),
+                    aux.span(),
+                ),
+            })
+            .map_err(
+                |Errored {
+                     command,
+                     errors,
+                     stderr,
+                     stdout,
+                 }| Errored {
+                    command,
+                    errors: vec![Error::Aux {
+                        path: aux_file.to_path_buf(),
+                        errors,
+                        line,
+                    }],
+                    stderr,
+                    stdout,
+                },
+            )?;
         cmd.args(extra_args);
         Ok(())
     }

--- a/src/build_manager.rs
+++ b/src/build_manager.rs
@@ -1,0 +1,116 @@
+//! Auxiliary and dependency builder. Extendable to custom builds.
+
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    ffi::OsString,
+    process::Command,
+    sync::{Arc, OnceLock, RwLock},
+};
+
+use crate::{status_emitter::StatusEmitter, Config, Errored};
+
+/// A build shared between all tests of the same `BuildManager`
+pub trait Build {
+    /// Runs the build and returns command line args to add to the test so it can find
+    /// the built things.
+    fn build(&self, build_manager: &BuildManager<'_>) -> Result<Vec<OsString>, Errored>;
+    /// Must uniquely describe the build, as it is used for checking that a value
+    /// has already been cached.
+    fn description(&self) -> String;
+}
+
+/// Deduplicates builds
+pub struct BuildManager<'a> {
+    #[allow(clippy::type_complexity)]
+    cache: RwLock<HashMap<String, Arc<OnceLock<Result<Vec<OsString>, ()>>>>>,
+    status_emitter: &'a dyn StatusEmitter,
+    config: Config,
+}
+
+impl<'a> BuildManager<'a> {
+    /// Create a new `BuildManager` for a specific `Config`. Each `Config` needs
+    /// to have its own.
+    pub fn new(status_emitter: &'a dyn StatusEmitter, config: Config) -> Self {
+        Self {
+            cache: Default::default(),
+            status_emitter,
+            config,
+        }
+    }
+    /// This function will block until the build is done and then return the arguments
+    /// that need to be passed in order to build the dependencies.
+    /// The error is only reported once, all follow up invocations of the same build will
+    /// have a generic error about a previous build failing.
+    pub fn build(&self, what: impl Build) -> Result<Vec<OsString>, Errored> {
+        let description = what.description();
+        // Fast path without much contention.
+        if let Some(res) = self
+            .cache
+            .read()
+            .unwrap()
+            .get(&description)
+            .and_then(|o| o.get())
+        {
+            return res.clone().map_err(|()| Errored {
+                command: Command::new(format!("{description:?}")),
+                errors: vec![],
+                stderr: b"previous build failed".to_vec(),
+                stdout: vec![],
+            });
+        }
+        let mut lock = self.cache.write().unwrap();
+        let once = match lock.entry(description) {
+            Entry::Occupied(entry) => {
+                if let Some(res) = entry.get().get() {
+                    return res.clone().map_err(|()| Errored {
+                        command: Command::new(format!("{:?}", what.description())),
+                        errors: vec![],
+                        stderr: b"previous build failed".to_vec(),
+                        stdout: vec![],
+                    });
+                }
+                entry.get().clone()
+            }
+            Entry::Vacant(entry) => {
+                let once = Arc::new(OnceLock::new());
+                entry.insert(once.clone());
+                once
+            }
+        };
+        drop(lock);
+
+        let mut err = None;
+        once.get_or_init(|| {
+            let build = self
+                .status_emitter
+                .register_test(what.description().into())
+                .for_revision("");
+            let res = what.build(self).map_err(|e| err = Some(e));
+            build.done(
+                &res.as_ref()
+                    .map(|_| crate::test_result::TestOk::Ok)
+                    .map_err(|()| Errored {
+                        command: Command::new(what.description()),
+                        errors: vec![],
+                        stderr: vec![],
+                        stdout: vec![],
+                    }),
+            );
+            res
+        })
+        .clone()
+        .map_err(|()| {
+            err.unwrap_or_else(|| Errored {
+                command: Command::new(what.description()),
+                errors: vec![],
+                stderr: b"previous build failed".to_vec(),
+                stdout: vec![],
+            })
+        })
+    }
+
+    /// The `Config` used for all builds.
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,12 +2,7 @@ use regex::bytes::Regex;
 use spanned::Spanned;
 
 use crate::{
-    custom_flags::{run::Run, rustfix::RustfixMode, Flag},
-    dependencies::build_dependencies,
-    filter::Match,
-    parser::CommandParserFunc,
-    per_test_config::{Comments, Condition, TestConfig},
-    CommandBuilder, Mode,
+    aux_builds::AuxBuilder, build_manager::BuildManager, custom_flags::{run::Run, rustfix::RustfixMode, Flag}, dependencies::build_dependencies, filter::Match, parser::CommandParserFunc, per_test_config::{Comments, Condition, TestConfig}, CommandBuilder, Errored, Mode
 };
 pub use color_eyre;
 use color_eyre::eyre::Result;
@@ -76,8 +71,9 @@ impl Config {
                 Box::new(Edition(self.0.clone()))
             }
 
-            fn apply(&self, cmd: &mut std::process::Command, _config: &TestConfig<'_>) {
+            fn apply(&self, cmd: &mut std::process::Command, _config: &TestConfig<'_>, _build_manager: &BuildManager<'_>) -> Result<(), Errored> {
                 cmd.arg("--edition").arg(&self.0);
+                Ok(())
             }
         }
 
@@ -100,13 +96,13 @@ impl Config {
             }
         }
 
-        let _ = comment_defaults
-            .base()
-            .custom
-            .insert("edition", Spanned::dummy(Box::new(Edition("2021".into()))));
+        let _ = comment_defaults.base().custom.insert(
+            "edition",
+            Spanned::dummy(vec![Box::new(Edition("2021".into()))]),
+        );
         let _ = comment_defaults.base().custom.insert(
             "rustfix",
-            Spanned::dummy(Box::new(RustfixMode::MachineApplicable)),
+            Spanned::dummy(vec![Box::new(RustfixMode::MachineApplicable)]),
         );
         let filters = vec![
             (Match::PathBackslash, b"/".to_vec()),
@@ -149,7 +145,7 @@ impl Config {
                 // args are ignored (can be used as comment)
                 let prev = parser
                     .custom
-                    .insert("no-rustfix", Spanned::new(Box::new(()), span.clone()));
+                    .insert("no-rustfix", Spanned::new(vec![Box::new(())], span.clone()));
                 parser.check(span, prev.is_none(), "cannot specify `no-rustfix` twice");
             });
 
@@ -158,7 +154,7 @@ impl Config {
             .insert("edition", |parser, args, span| {
                 let prev = parser.custom.insert(
                     "edition",
-                    Spanned::new(Box::new(Edition((*args).into())), args.span()),
+                    Spanned::new(vec![Box::new(Edition((*args).into()))], args.span()),
                 );
                 parser.check(span, prev.is_none(), "cannot specify `edition` twice");
             });
@@ -168,7 +164,7 @@ impl Config {
             .insert("needs-asm-support", |parser, args, span| {
                 let prev = parser.custom.insert(
                     "needs-asm-support",
-                    Spanned::new(Box::new(NeedsAsmSupport), args.span()),
+                    Spanned::new(vec![Box::new(NeedsAsmSupport)], args.span()),
                 );
                 parser.check(
                     span,
@@ -186,13 +182,13 @@ impl Config {
             let set = |exit_code| {
                 parser.custom.insert(
                     "run",
-                    Spanned::new(Box::new(Run { exit_code }), args.span()),
+                    Spanned::new(vec![Box::new(Run { exit_code })], args.span()),
                 );
                 parser.mode = Spanned::new(Mode::Pass, args.span()).into();
 
                 let prev = parser
                     .custom
-                    .insert("no-rustfix", Spanned::new(Box::new(()), span.clone()));
+                    .insert("no-rustfix", Spanned::new(vec![Box::new(())], span.clone()));
                 parser.check(span, prev.is_none(), "`run` implies `no-rustfix`");
             };
             if args.is_empty() {
@@ -205,6 +201,22 @@ impl Config {
                     Err(err) => parser.error(args.span(), err.to_string()),
                 }
             }
+        });
+        config.custom_comments.insert("aux-build", |parser, args, span| {
+            let name = match args.split_once(":") {
+                Some((name, rest)) => {
+                    parser.error(rest.span(), "proc macros are now auto-detected, you can remove the `:proc-macro` after the file name");
+                    name
+                },
+                None => args,
+            };
+            
+            parser
+                .custom
+                .entry("aux-build")
+                .or_insert_with(|| Spanned::new(vec![], span))
+                .content
+                .push(Box::new(AuxBuilder { aux_file: name.map(|n| n.into())}));
         });
         config
     }
@@ -408,10 +420,11 @@ impl Config {
         {
             return self.run_only_ignored;
         }
-        if comments
-            .for_revision(revision)
-            .any(|r| r.custom.values().any(|flag| flag.test_condition(self)))
-        {
+        if comments.for_revision(revision).any(|r| {
+            r.custom
+                .values()
+                .any(|flags| flags.content.iter().any(|flag| flag.test_condition(self)))
+        }) {
             return self.run_only_ignored;
         }
         comments

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ use crate::{
 pub use color_eyre;
 use color_eyre::eyre::Result;
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     ffi::OsString,
     num::NonZeroUsize,
     path::{Path, PathBuf},
@@ -61,7 +61,7 @@ pub struct Config {
     /// The default settings settable via `@` comments
     pub comment_defaults: Comments,
     /// Custom comment parsers
-    pub custom_comments: HashMap<&'static str, CommandParserFunc>,
+    pub custom_comments: BTreeMap<&'static str, CommandParserFunc>,
 }
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,14 @@ use regex::bytes::Regex;
 use spanned::Spanned;
 
 use crate::{
-    aux_builds::AuxBuilder, build_manager::BuildManager, custom_flags::{run::Run, rustfix::RustfixMode, Flag}, dependencies::build_dependencies, filter::Match, parser::CommandParserFunc, per_test_config::{Comments, Condition, TestConfig}, CommandBuilder, Errored, Mode
+    aux_builds::AuxBuilder,
+    build_manager::BuildManager,
+    custom_flags::{run::Run, rustfix::RustfixMode, Flag},
+    dependencies::build_dependencies,
+    filter::Match,
+    parser::CommandParserFunc,
+    per_test_config::{Comments, Condition, TestConfig},
+    CommandBuilder, Errored, Mode,
 };
 pub use color_eyre;
 use color_eyre::eyre::Result;
@@ -71,7 +78,12 @@ impl Config {
                 Box::new(Edition(self.0.clone()))
             }
 
-            fn apply(&self, cmd: &mut std::process::Command, _config: &TestConfig<'_>, _build_manager: &BuildManager<'_>) -> Result<(), Errored> {
+            fn apply(
+                &self,
+                cmd: &mut std::process::Command,
+                _config: &TestConfig<'_>,
+                _build_manager: &BuildManager<'_>,
+            ) -> Result<(), Errored> {
                 cmd.arg("--edition").arg(&self.0);
                 Ok(())
             }
@@ -210,7 +222,7 @@ impl Config {
                 },
                 None => args,
             };
-            
+
             parser
                 .custom
                 .entry("aux-build")

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,11 +2,11 @@ use regex::bytes::Regex;
 use spanned::Spanned;
 
 use crate::{
-    core::Flag,
+    custom_flags::{run::Run, Flag},
     dependencies::build_dependencies,
     filter::Match,
     parser::CommandParserFunc,
-    per_test_config::{Comments, Condition, Run, TestConfig},
+    per_test_config::{Comments, Condition, TestConfig},
     CommandBuilder, Errored, Mode, RustfixMode,
 };
 pub use color_eyre;

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use crate::{
     dependencies::build_dependencies,
     filter::Match,
     parser::CommandParserFunc,
-    per_test_config::{Comments, Condition},
+    per_test_config::{Comments, Condition, TestConfig},
     CommandBuilder, Mode,
 };
 pub use color_eyre;
@@ -76,7 +76,7 @@ impl Config {
                 Box::new(Edition(self.0.clone()))
             }
 
-            fn apply(&self, cmd: &mut std::process::Command) {
+            fn apply(&self, cmd: &mut std::process::Command, _config: &TestConfig<'_>) {
                 cmd.arg("--edition").arg(&self.0);
             }
         }

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,15 +1,12 @@
 //! Basic operations useful for building a testsuite
 
-use crate::per_test_config::TestConfig;
 use crate::test_result::Errored;
-use crate::Config;
 use bstr::ByteSlice as _;
 use color_eyre::eyre::Result;
 use crossbeam_channel::unbounded;
 use crossbeam_channel::Receiver;
 use crossbeam_channel::Sender;
 use std::num::NonZeroUsize;
-use std::panic::UnwindSafe;
 use std::path::Component;
 use std::path::Path;
 use std::path::Prefix;
@@ -121,41 +118,4 @@ pub fn run_and_collect<SUBMISSION: Send, RESULT: Send>(
         }
         Ok(())
     })
-}
-
-/// Tester-specific flag that gets parsed from `//@` comments.
-pub trait Flag: Send + Sync + UnwindSafe + std::fmt::Debug {
-    /// Clone the boxed value and create a new box.
-    fn clone_inner(&self) -> Box<dyn Flag>;
-
-    /// Modify a command to what the flag specifies
-    fn apply(&self, _cmd: &mut Command) {}
-
-    /// Whether this flag causes a test to be filtered out
-    fn test_condition(&self, _config: &Config) -> bool {
-        false
-    }
-
-    /// Run an action after a test is finished.
-    /// Returns the `cmd` back if no action was taken.
-    fn post_test_action(
-        &self,
-        _config: &TestConfig<'_>,
-        cmd: Command,
-        _output: &Output,
-    ) -> Result<Option<Command>, Errored> {
-        Ok(Some(cmd))
-    }
-}
-
-impl Flag for () {
-    fn clone_inner(&self) -> Box<dyn Flag> {
-        Box::new(())
-    }
-}
-
-impl Clone for Box<dyn Flag> {
-    fn clone(&self) -> Self {
-        self.clone_inner()
-    }
 }

--- a/src/custom_flags.rs
+++ b/src/custom_flags.rs
@@ -1,7 +1,7 @@
 //! Define custom test flags not natively supported by ui_test
 
 use std::{
-    panic::UnwindSafe,
+    panic::{RefUnwindSafe, UnwindSafe},
     process::{Command, Output},
 };
 
@@ -11,7 +11,7 @@ pub mod run;
 pub mod rustfix;
 
 /// Tester-specific flag that gets parsed from `//@` comments.
-pub trait Flag: Send + Sync + UnwindSafe + std::fmt::Debug {
+pub trait Flag: Send + Sync + UnwindSafe + RefUnwindSafe + std::fmt::Debug {
     /// Clone the boxed value and create a new box.
     fn clone_inner(&self) -> Box<dyn Flag>;
 

--- a/src/custom_flags.rs
+++ b/src/custom_flags.rs
@@ -1,0 +1,48 @@
+//! Define custom test flags not natively supported by ui_test
+
+use std::{
+    panic::UnwindSafe,
+    process::{Command, Output},
+};
+
+use crate::{per_test_config::TestConfig, Config, Errored};
+
+pub mod run;
+
+/// Tester-specific flag that gets parsed from `//@` comments.
+pub trait Flag: Send + Sync + UnwindSafe + std::fmt::Debug {
+    /// Clone the boxed value and create a new box.
+    fn clone_inner(&self) -> Box<dyn Flag>;
+
+    /// Modify a command to what the flag specifies
+    fn apply(&self, _cmd: &mut Command) {}
+
+    /// Whether this flag causes a test to be filtered out
+    fn test_condition(&self, _config: &Config) -> bool {
+        false
+    }
+
+    /// Run an action after a test is finished.
+    /// Returns the `cmd` back if no action was taken.
+    fn post_test_action(
+        &self,
+        _config: &TestConfig<'_>,
+        cmd: Command,
+        _output: &Output,
+    ) -> Result<Option<Command>, Errored> {
+        Ok(Some(cmd))
+    }
+}
+
+/// Use the unit type for when you don't need any behaviour and just need to know if the flag was set or not.
+impl Flag for () {
+    fn clone_inner(&self) -> Box<dyn Flag> {
+        Box::new(())
+    }
+}
+
+impl Clone for Box<dyn Flag> {
+    fn clone(&self) -> Self {
+        self.clone_inner()
+    }
+}

--- a/src/custom_flags.rs
+++ b/src/custom_flags.rs
@@ -8,6 +8,7 @@ use std::{
 use crate::{per_test_config::TestConfig, Config, Errored};
 
 pub mod run;
+pub mod rustfix;
 
 /// Tester-specific flag that gets parsed from `//@` comments.
 pub trait Flag: Send + Sync + UnwindSafe + std::fmt::Debug {

--- a/src/custom_flags.rs
+++ b/src/custom_flags.rs
@@ -16,7 +16,14 @@ pub trait Flag: Send + Sync + UnwindSafe + RefUnwindSafe + std::fmt::Debug {
     fn clone_inner(&self) -> Box<dyn Flag>;
 
     /// Modify a command to what the flag specifies
-    fn apply(&self, _cmd: &mut Command, _config: &TestConfig<'_>) {}
+    fn apply(
+        &self,
+        _cmd: &mut Command,
+        _config: &TestConfig<'_>,
+        _build_manager: &BuildManager<'_>,
+    ) -> Result<(), Errored> {
+        Ok(())
+    }
 
     /// Whether this flag causes a test to be filtered out
     fn test_condition(&self, _config: &Config) -> bool {

--- a/src/custom_flags.rs
+++ b/src/custom_flags.rs
@@ -16,7 +16,7 @@ pub trait Flag: Send + Sync + UnwindSafe + RefUnwindSafe + std::fmt::Debug {
     fn clone_inner(&self) -> Box<dyn Flag>;
 
     /// Modify a command to what the flag specifies
-    fn apply(&self, _cmd: &mut Command) {}
+    fn apply(&self, _cmd: &mut Command, _config: &TestConfig<'_>) {}
 
     /// Whether this flag causes a test to be filtered out
     fn test_condition(&self, _config: &Config) -> bool {

--- a/src/custom_flags.rs
+++ b/src/custom_flags.rs
@@ -5,7 +5,7 @@ use std::{
     process::{Command, Output},
 };
 
-use crate::{per_test_config::TestConfig, Config, Errored};
+use crate::{build_manager::BuildManager, per_test_config::TestConfig, Config, Errored};
 
 pub mod run;
 pub mod rustfix;
@@ -30,6 +30,7 @@ pub trait Flag: Send + Sync + UnwindSafe + RefUnwindSafe + std::fmt::Debug {
         _config: &TestConfig<'_>,
         cmd: Command,
         _output: &Output,
+        _build_manager: &BuildManager<'_>,
     ) -> Result<Option<Command>, Errored> {
         Ok(Some(cmd))
     }

--- a/src/custom_flags/run.rs
+++ b/src/custom_flags/run.rs
@@ -1,0 +1,27 @@
+//! Types used for running tests after they pass compilation
+
+use std::process::{Command, Output};
+
+use crate::{per_test_config::TestConfig, Errored};
+
+use super::Flag;
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct Run {
+    pub exit_code: i32,
+}
+
+impl Flag for Run {
+    fn clone_inner(&self) -> Box<dyn Flag> {
+        Box::new(*self)
+    }
+    fn post_test_action(
+        &self,
+        config: &TestConfig<'_>,
+        cmd: Command,
+        _output: &Output,
+    ) -> Result<Option<Command>, Errored> {
+        config.run_test_binary(cmd, self.exit_code)?;
+        Ok(None)
+    }
+}

--- a/src/custom_flags/run.rs
+++ b/src/custom_flags/run.rs
@@ -1,8 +1,9 @@
 //! Types used for running tests after they pass compilation
 
+use bstr::ByteSlice;
 use std::process::{Command, Output};
 
-use crate::{per_test_config::TestConfig, Errored};
+use crate::{per_test_config::TestConfig, Error, Errored};
 
 use super::Flag;
 
@@ -15,13 +16,61 @@ impl Flag for Run {
     fn clone_inner(&self) -> Box<dyn Flag> {
         Box::new(*self)
     }
+
     fn post_test_action(
         &self,
         config: &TestConfig<'_>,
         cmd: Command,
         _output: &Output,
     ) -> Result<Option<Command>, Errored> {
-        config.run_test_binary(cmd, self.exit_code)?;
-        Ok(None)
+        let mut cmd = cmd;
+        let exit_code = self.exit_code;
+        let revision = config.extension("run");
+        let config = TestConfig {
+            config: config.config.clone(),
+            revision: &revision,
+            comments: config.comments,
+            path: config.path,
+        };
+        cmd.arg("--print").arg("file-names");
+        let output = cmd.output().unwrap();
+        assert!(output.status.success());
+
+        let mut files = output.stdout.lines();
+        let file = files.next().unwrap();
+        assert_eq!(files.next(), None);
+        let file = std::str::from_utf8(file).unwrap();
+        let exe_file = config.config.out_dir.join(file);
+        let mut exe = Command::new(&exe_file);
+        let stdin = config.path.with_extension(format!("{revision}.stdin"));
+        if stdin.exists() {
+            exe.stdin(std::fs::File::open(stdin).unwrap());
+        }
+        let output = exe
+            .output()
+            .unwrap_or_else(|err| panic!("exe file: {}: {err}", exe_file.display()));
+
+        let mut errors = vec![];
+
+        config.check_test_output(&mut errors, &output.stdout, &output.stderr);
+
+        let status = output.status;
+        if status.code() != Some(exit_code) {
+            errors.push(Error::ExitStatus {
+                mode: format!("run({exit_code})"),
+                status,
+                expected: exit_code,
+            })
+        }
+        if errors.is_empty() {
+            Ok(None)
+        } else {
+            Err(Errored {
+                command: exe,
+                errors,
+                stderr: vec![],
+                stdout: vec![],
+            })
+        }
     }
 }

--- a/src/custom_flags/run.rs
+++ b/src/custom_flags/run.rs
@@ -3,7 +3,7 @@
 use bstr::ByteSlice;
 use std::process::{Command, Output};
 
-use crate::{per_test_config::TestConfig, Error, Errored};
+use crate::{build_manager::BuildManager, per_test_config::TestConfig, Error, Errored};
 
 use super::Flag;
 
@@ -22,6 +22,7 @@ impl Flag for Run {
         config: &TestConfig<'_>,
         cmd: Command,
         _output: &Output,
+        _build_manager: &BuildManager<'_>,
     ) -> Result<Option<Command>, Errored> {
         let mut cmd = cmd;
         let exit_code = self.exit_code;
@@ -31,6 +32,7 @@ impl Flag for Run {
             revision: &revision,
             comments: config.comments,
             path: config.path,
+            aux_dir: config.aux_dir,
         };
         cmd.arg("--print").arg("file-names");
         let output = cmd.output().unwrap();

--- a/src/custom_flags/rustfix.rs
+++ b/src/custom_flags/rustfix.rs
@@ -1,0 +1,191 @@
+//! All the logic needed to run rustfix on a test that failed compilation
+
+use std::{
+    collections::HashSet,
+    process::{Command, Output},
+};
+
+use spanned::Span;
+
+use crate::{
+    parser::OptWithLine,
+    per_test_config::{Comments, Revisioned, TestConfig},
+    rustc_stderr, Error, Errored, Mode,
+};
+
+use super::Flag;
+
+/// When to run rustfix on tests
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RustfixMode {
+    /// Do not run rustfix on the test
+    Disabled,
+    /// Apply only `MachineApplicable` suggestions emitted by the test
+    MachineApplicable,
+    /// Apply all suggestions emitted by the test
+    Everything,
+}
+
+impl RustfixMode {
+    pub(crate) fn enabled(self) -> bool {
+        self != RustfixMode::Disabled
+    }
+}
+
+impl Flag for RustfixMode {
+    fn clone_inner(&self) -> Box<dyn Flag> {
+        Box::new(*self)
+    }
+    fn post_test_action(
+        &self,
+        config: &TestConfig<'_>,
+        cmd: Command,
+        output: &Output,
+    ) -> Result<Option<Command>, Errored> {
+        let global_rustfix = match *config.mode()? {
+            Mode::Pass | Mode::Panic => RustfixMode::Disabled,
+            Mode::Fail { .. } | Mode::Yolo => *self,
+        };
+
+        let output = output.clone();
+        let no_run_rustfix = config.find_one_custom("no-rustfix")?;
+
+        let fixed_code = (no_run_rustfix.is_none() && global_rustfix.enabled())
+            .then_some(())
+            .and_then(|()| {
+                let suggestions = std::str::from_utf8(&output.stderr)
+                    .unwrap()
+                    .lines()
+                    .flat_map(|line| {
+                        if !line.starts_with('{') {
+                            return vec![];
+                        }
+                        rustfix::get_suggestions_from_json(
+                            line,
+                            &HashSet::new(),
+                            if global_rustfix == RustfixMode::Everything {
+                                rustfix::Filter::Everything
+                            } else {
+                                rustfix::Filter::MachineApplicableOnly
+                            },
+                        )
+                        .unwrap_or_else(|err| {
+                            panic!("could not deserialize diagnostics json for rustfix {err}:{line}")
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                if suggestions.is_empty() {
+                    None
+                } else {
+                    let path_str = config.path.display().to_string();
+                    for sugg in &suggestions {
+                        for snip in &sugg.snippets {
+                            if snip.file_name != path_str {
+                                return Some(Err(anyhow::anyhow!("cannot apply suggestions for `{}` since main file is `{path_str}`. Please use `//@no-rustfix` to disable rustfix", snip.file_name)));
+                            }
+                        }
+                    }
+                    Some(rustfix::apply_suggestions(
+                        &std::fs::read_to_string(config.path).unwrap(),
+                        &suggestions,
+                    ))
+                }
+            })
+            .transpose()
+            .map_err(|err| Errored {
+                command: Command::new(format!("rustfix {}", config.path.display())),
+                errors: vec![Error::Rustfix(err)],
+                stderr: output.stderr,
+                stdout: output.stdout,
+            })?;
+
+        let rustfix_comments = Comments {
+            revisions: None,
+            revisioned: std::iter::once((
+                vec![],
+                Revisioned {
+                    span: Span::default(),
+                    ignore: vec![],
+                    only: vec![],
+                    stderr_per_bitwidth: false,
+                    compile_flags: config.collect(|r| r.compile_flags.iter().cloned()),
+                    env_vars: config.collect(|r| r.env_vars.iter().cloned()),
+                    normalize_stderr: vec![],
+                    normalize_stdout: vec![],
+                    error_in_other_files: vec![],
+                    error_matches: vec![],
+                    require_annotations_for_level: Default::default(),
+                    aux_builds: config.collect(|r| r.aux_builds.iter().cloned()),
+                    mode: OptWithLine::new(Mode::Pass, Span::default()),
+                    diagnostic_code_prefix: OptWithLine::new(String::new(), Span::default()),
+                    custom: config
+                        .comments
+                        .for_revision(config.revision)
+                        .flat_map(|r| r.custom.clone())
+                        .collect(),
+                },
+            ))
+            .collect(),
+        };
+        let config = TestConfig {
+            config: config.config.clone(),
+            revision: config.revision,
+            comments: &rustfix_comments,
+            path: config.path,
+        };
+
+        let run = fixed_code.is_some();
+        let mut errors = vec![];
+        let rustfix_path = config.check_output(
+            // Always check for `.fixed` files, even if there were reasons not to run rustfix.
+            // We don't want to leave around stray `.fixed` files
+            fixed_code.unwrap_or_default().as_bytes(),
+            &mut errors,
+            "fixed",
+        );
+        // picking the crate name from the file name is problematic when `.revision_name` is inserted,
+        // so we compute it here before replacing the path.
+        let crate_name = config
+            .path
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .replace('-', "_");
+        let config = TestConfig {
+            config: config.config,
+            revision: config.revision,
+            comments: &rustfix_comments,
+            path: &rustfix_path,
+        };
+        if !errors.is_empty() {
+            return Err(Errored {
+                command: Command::new(format!("checking {}", config.path.display())),
+                errors,
+                stderr: vec![],
+                stdout: vec![],
+            });
+        }
+
+        if !run {
+            return Ok(Some(cmd));
+        }
+
+        let mut cmd = config.build_command()?;
+        cmd.arg("--crate-name").arg(crate_name);
+        let output = cmd.output().unwrap();
+        if output.status.success() {
+            Ok(None)
+        } else {
+            Err(Errored {
+                command: cmd,
+                errors: vec![Error::Command {
+                    kind: "rustfix".into(),
+                    status: output.status,
+                }],
+                stderr: rustc_stderr::process(&rustfix_path, &output.stderr).rendered,
+                stdout: output.stdout,
+            })
+        }
+    }
+}

--- a/src/custom_flags/rustfix.rs
+++ b/src/custom_flags/rustfix.rs
@@ -117,7 +117,6 @@ impl Flag for RustfixMode {
                     error_in_other_files: vec![],
                     error_matches: vec![],
                     require_annotations_for_level: Default::default(),
-                    aux_builds: config.collect(|r| r.aux_builds.iter().cloned()),
                     mode: OptWithLine::new(Mode::Pass, Span::default()),
                     diagnostic_code_prefix: OptWithLine::new(String::new(), Span::default()),
                     custom: config

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -2,16 +2,17 @@ use cargo_metadata::{camino::Utf8PathBuf, DependencyKind};
 use cargo_platform::Cfg;
 use color_eyre::eyre::{bail, eyre, Result};
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     ffi::OsString,
     path::PathBuf,
     process::Command,
     str::FromStr,
-    sync::{Arc, OnceLock, RwLock},
 };
 
 use crate::{
-    status_emitter::StatusEmitter, test_result::Errored, Config, Mode, OutputConflictHandling,
+    build_manager::{Build, BuildManager},
+    test_result::Errored,
+    Config, Mode, OutputConflictHandling,
 };
 
 #[derive(Default, Debug)]
@@ -207,15 +208,6 @@ pub(crate) fn build_dependencies(config: &Config) -> Result<Dependencies> {
     bail!("no json found in cargo-metadata output")
 }
 
-pub trait Build {
-    /// Runs the build and returns command line args to add to the test so it can find
-    /// the built things.
-    fn build(&self, build_manager: &BuildManager<'_>) -> Result<Vec<OsString>, Errored>;
-    /// Must uniquely describe the build, as it is used for checking that a value
-    /// has already been cached.
-    fn description(&self) -> String;
-}
-
 /// Build the dependencies.
 pub struct DependencyBuilder;
 
@@ -234,97 +226,5 @@ impl Build for DependencyBuilder {
 
     fn description(&self) -> String {
         "Building dependencies".into()
-    }
-}
-
-pub struct BuildManager<'a> {
-    #[allow(clippy::type_complexity)]
-    cache: RwLock<HashMap<String, Arc<OnceLock<Result<Vec<OsString>, ()>>>>>,
-    status_emitter: &'a dyn StatusEmitter,
-    config: Config,
-}
-
-impl<'a> BuildManager<'a> {
-    pub fn new(status_emitter: &'a dyn StatusEmitter, config: Config) -> Self {
-        Self {
-            cache: Default::default(),
-            status_emitter,
-            config,
-        }
-    }
-    /// This function will block until the build is done and then return the arguments
-    /// that need to be passed in order to build the dependencies.
-    /// The error is only reported once, all follow up invocations of the same build will
-    /// have a generic error about a previous build failing.
-    pub fn build(&self, what: impl Build) -> Result<Vec<OsString>, Errored> {
-        let description = what.description();
-        // Fast path without much contention.
-        if let Some(res) = self
-            .cache
-            .read()
-            .unwrap()
-            .get(&description)
-            .and_then(|o| o.get())
-        {
-            return res.clone().map_err(|()| Errored {
-                command: Command::new(format!("{description:?}")),
-                errors: vec![],
-                stderr: b"previous build failed".to_vec(),
-                stdout: vec![],
-            });
-        }
-        let mut lock = self.cache.write().unwrap();
-        let once = match lock.entry(description) {
-            Entry::Occupied(entry) => {
-                if let Some(res) = entry.get().get() {
-                    return res.clone().map_err(|()| Errored {
-                        command: Command::new(format!("{:?}", what.description())),
-                        errors: vec![],
-                        stderr: b"previous build failed".to_vec(),
-                        stdout: vec![],
-                    });
-                }
-                entry.get().clone()
-            }
-            Entry::Vacant(entry) => {
-                let once = Arc::new(OnceLock::new());
-                entry.insert(once.clone());
-                once
-            }
-        };
-        drop(lock);
-
-        let mut err = None;
-        once.get_or_init(|| {
-            let build = self
-                .status_emitter
-                .register_test(what.description().into())
-                .for_revision("");
-            let res = what.build(self).map_err(|e| err = Some(e));
-            build.done(
-                &res.as_ref()
-                    .map(|_| crate::test_result::TestOk::Ok)
-                    .map_err(|()| Errored {
-                        command: Command::new(what.description()),
-                        errors: vec![],
-                        stderr: vec![],
-                        stdout: vec![],
-                    }),
-            );
-            res
-        })
-        .clone()
-        .map_err(|()| {
-            err.unwrap_or_else(|| Errored {
-                command: Command::new(what.description()),
-                errors: vec![],
-                stderr: b"previous build failed".to_vec(),
-                stdout: vec![],
-            })
-        })
-    }
-
-    pub fn config(&self) -> &Config {
-        &self.config
     }
 }

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -1,23 +1,17 @@
-use bstr::ByteSlice;
 use cargo_metadata::{camino::Utf8PathBuf, DependencyKind};
 use cargo_platform::Cfg;
 use color_eyre::eyre::{bail, eyre, Result};
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
     ffi::OsString,
-    path::{Path, PathBuf},
+    path::PathBuf,
     process::Command,
     str::FromStr,
     sync::{Arc, OnceLock, RwLock},
 };
 
 use crate::{
-    default_per_file_config,
-    per_test_config::{Comments, TestConfig},
-    rustc_stderr,
-    status_emitter::StatusEmitter,
-    test_result::Errored,
-    Config, CrateType, Error, Mode, OutputConflictHandling,
+    status_emitter::StatusEmitter, test_result::Errored, Config, Mode, OutputConflictHandling,
 };
 
 #[derive(Default, Debug)]
@@ -243,22 +237,6 @@ impl Build for DependencyBuilder {
     }
 }
 
-/// Build an aux-build.
-pub struct AuxBuilder {
-    pub aux_file: PathBuf,
-}
-
-impl Build for AuxBuilder {
-    fn build(&self, build_manager: &BuildManager<'_>) -> Result<Vec<OsString>, Errored> {
-        let args = build_manager.build_aux(&self.aux_file, build_manager.config().clone())?;
-        Ok(args.iter().map(Into::into).collect())
-    }
-
-    fn description(&self) -> String {
-        format!("Building aux file {}", self.aux_file.display())
-    }
-}
-
 pub struct BuildManager<'a> {
     #[allow(clippy::type_complexity)]
     cache: RwLock<HashMap<String, Arc<OnceLock<Result<Vec<OsString>, ()>>>>>,
@@ -344,84 +322,6 @@ impl<'a> BuildManager<'a> {
                 stdout: vec![],
             })
         })
-    }
-
-    fn build_aux(
-        &self,
-        aux_file: &Path,
-        mut config: Config,
-    ) -> std::result::Result<Vec<OsString>, Errored> {
-        let file_contents = std::fs::read(aux_file).map_err(|err| Errored {
-            command: Command::new(format!("reading aux file `{}`", aux_file.display())),
-            errors: vec![],
-            stderr: err.to_string().into_bytes(),
-            stdout: vec![],
-        })?;
-        let comments = Comments::parse(&file_contents, &config, aux_file)
-            .map_err(|errors| Errored::new(errors, "parse aux comments"))?;
-        assert_eq!(
-            comments.revisions, None,
-            "aux builds cannot specify revisions"
-        );
-
-        default_per_file_config(&mut config, aux_file, &file_contents);
-
-        match CrateType::from_file_contents(&file_contents) {
-            // Proc macros must be run on the host
-            CrateType::ProcMacro => config.target = config.host.clone(),
-            CrateType::Test | CrateType::Bin | CrateType::Lib => {}
-        }
-
-        let mut config = TestConfig {
-            config,
-            revision: "",
-            comments: &comments,
-            path: aux_file,
-        };
-
-        config.patch_out_dir();
-
-        let mut aux_cmd = config.build_command()?;
-
-        let mut extra_args = config.build_aux_files(aux_file.parent().unwrap(), self)?;
-        // Make sure we see our dependencies
-        aux_cmd.args(extra_args.iter());
-
-        aux_cmd.arg("--emit=link");
-        let filename = aux_file.file_stem().unwrap().to_str().unwrap();
-        let output = aux_cmd.output().unwrap();
-        if !output.status.success() {
-            let error = Error::Command {
-                kind: "compilation of aux build failed".to_string(),
-                status: output.status,
-            };
-            return Err(Errored {
-                command: aux_cmd,
-                errors: vec![error],
-                stderr: rustc_stderr::process(aux_file, &output.stderr).rendered,
-                stdout: output.stdout,
-            });
-        }
-
-        // Now run the command again to fetch the output filenames
-        aux_cmd.arg("--print").arg("file-names");
-        let output = aux_cmd.output().unwrap();
-        assert!(output.status.success());
-
-        for file in output.stdout.lines() {
-            let file = std::str::from_utf8(file).unwrap();
-            let crate_name = filename.replace('-', "_");
-            let path = config.config.out_dir.join(file);
-            extra_args.push("--extern".into());
-            let mut cname = OsString::from(&crate_name);
-            cname.push("=");
-            cname.push(path);
-            extra_args.push(cname);
-            // Help cargo find the crates added with `--extern`.
-            extra_args.push("-L".into());
-            extra_args.push(config.config.out_dir.as_os_str().to_os_string());
-        }
-        Ok(extra_args)
     }
 
     pub fn config(&self) -> &Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub use test_result::{Errored, TestOk};
 use crate::dependencies::DependencyBuilder;
 use crate::parser::Comments;
 
+pub mod aux_builds;
 mod cmd;
 mod config;
 pub mod core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use color_eyre::eyre::Context as _;
 pub use color_eyre::eyre::Result;
 pub use core::run_and_collect;
 pub use core::CrateType;
-use dependencies::{Build, BuildManager};
+use dependencies::BuildManager;
 pub use filter::Match;
 use per_test_config::TestConfig;
 use rustc_stderr::Message;
@@ -25,6 +25,7 @@ use std::process::Command;
 use test_result::TestRun;
 pub use test_result::{Errored, TestOk};
 
+use crate::dependencies::DependencyBuilder;
 use crate::parser::Comments;
 
 mod cmd;
@@ -328,7 +329,7 @@ fn parse_and_test_file(
 
             if !built_deps {
                 status.update_status("waiting for dependencies to finish building".into());
-                match build_manager.build(Build::Dependencies) {
+                match build_manager.build(DependencyBuilder) {
                     Ok(extra_args) => config.program.args.extend(extra_args),
                     Err(err) => {
                         return TestRun {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,13 @@
 
 //! A crate to run the Rust compiler (or other binaries) and test their command line output.
 
+use build_manager::BuildManager;
 pub use color_eyre;
 use color_eyre::eyre::eyre;
 use color_eyre::eyre::Context as _;
 pub use color_eyre::eyre::Result;
 pub use core::run_and_collect;
 pub use core::CrateType;
-use dependencies::BuildManager;
 pub use filter::Match;
 use per_test_config::TestConfig;
 use rustc_stderr::Message;
@@ -29,6 +29,7 @@ use crate::dependencies::DependencyBuilder;
 use crate::parser::Comments;
 
 pub mod aux_builds;
+pub mod build_manager;
 mod cmd;
 mod config;
 pub mod core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,9 +139,11 @@ pub fn test_command(mut config: Config, path: &Path) -> Result<Command> {
         config,
         revision: "",
         comments: &comments,
+        aux_dir: &path.parent().unwrap().join("auxiliary"),
         path,
     };
-    let mut result = config.build_command().unwrap();
+    let build_manager = BuildManager::new(&(), config.config.clone());
+    let mut result = config.build_command(&build_manager).unwrap();
     result.args(extra_args);
 
     Ok(result)
@@ -349,6 +351,7 @@ fn parse_and_test_file(
                 revision,
                 comments: &comments,
                 path: status.path(),
+                aux_dir: &status.path().parent().unwrap().join("auxiliary"),
             };
 
             let result = test_config.run_test(build_manager);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ use crate::parser::Comments;
 mod cmd;
 mod config;
 pub mod core;
+pub mod custom_flags;
 mod dependencies;
 mod diff;
 mod error;

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -2,23 +2,6 @@ use super::Error;
 use std::fmt::Display;
 use std::process::ExitStatus;
 
-/// When to run rustfix on tests
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum RustfixMode {
-    /// Do not run rustfix on the test
-    Disabled,
-    /// Apply only `MachineApplicable` suggestions emitted by the test
-    MachineApplicable,
-    /// Apply all suggestions emitted by the test
-    Everything,
-}
-
-impl RustfixMode {
-    pub(crate) fn enabled(self) -> bool {
-        self != RustfixMode::Disabled
-    }
-}
-
 #[derive(Copy, Clone, Debug)]
 /// Decides what is expected of each test's exit status.
 pub enum Mode {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -121,14 +121,6 @@ impl Comments {
             })?;
         Ok(mode)
     }
-
-    pub(crate) fn apply_custom(&self, revision: &str, cmd: &mut Command) {
-        for rev in self.for_revision(revision) {
-            for flag in rev.custom.values() {
-                flag.content.apply(cmd);
-            }
-        }
-    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, num::NonZeroUsize, path::Path, process::Command};
+use std::{
+    collections::{BTreeMap, HashMap},
+    num::NonZeroUsize,
+    path::Path,
+    process::Command,
+};
 
 use bstr::{ByteSlice, Utf8Error};
 use regex::bytes::Regex;
@@ -25,7 +30,7 @@ pub struct Comments {
     pub revisions: Option<Vec<String>>,
     /// Comments that are only available under specific revisions.
     /// The defaults are in key `vec![]`
-    pub revisioned: HashMap<Vec<String>, Revisioned>,
+    pub revisioned: BTreeMap<Vec<String>, Revisioned>,
 }
 
 impl Default for Comments {
@@ -155,7 +160,7 @@ pub struct Revisioned {
     /// The keys are just labels for overwriting or retrieving the value later.
     /// They are mostly used by `Config::custom_comments` handlers,
     /// `ui_test` itself only ever looks at the values, not the keys.
-    pub custom: HashMap<&'static str, Spanned<Vec<Box<dyn Flag>>>>,
+    pub custom: BTreeMap<&'static str, Spanned<Vec<Box<dyn Flag>>>>,
 }
 
 /// Main entry point to parsing comments and handling parsing errors.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,7 +9,8 @@ use bstr::{ByteSlice, Utf8Error};
 use regex::bytes::Regex;
 
 use crate::{
-    core::Flag, filter::Match, rustc_stderr::Level, test_result::Errored, Config, Error, Mode,
+    custom_flags::Flag, filter::Match, rustc_stderr::Level, test_result::Errored, Config, Error,
+    Mode,
 };
 
 use color_eyre::eyre::Result;

--- a/src/per_test_config.rs
+++ b/src/per_test_config.rs
@@ -75,6 +75,14 @@ impl TestConfig<'_> {
         self.comments().flat_map(f).collect()
     }
 
+    fn apply_custom(&self, cmd: &mut Command) {
+        for rev in self.comments.for_revision(self.revision) {
+            for flag in rev.custom.values() {
+                flag.content.apply(cmd);
+            }
+        }
+    }
+
     pub(crate) fn build_command(&self) -> Result<Command, Errored> {
         let TestConfig {
             config,
@@ -94,7 +102,7 @@ impl TestConfig<'_> {
             cmd.arg(arg);
         }
 
-        comments.apply_custom(revision, &mut cmd);
+        self.apply_custom(&mut cmd);
 
         if let Some(target) = &config.target {
             // Adding a `--target` arg to calls to Cargo will cause target folders

--- a/src/per_test_config.rs
+++ b/src/per_test_config.rs
@@ -10,8 +10,9 @@ use std::process::{Command, Output};
 
 use spanned::Spanned;
 
+use crate::aux_builds::AuxBuilder;
 use crate::custom_flags::Flag;
-use crate::dependencies::{AuxBuilder, BuildManager};
+use crate::dependencies::BuildManager;
 pub use crate::parser::{Comments, Condition, Revisioned};
 use crate::parser::{ErrorMatch, ErrorMatchKind, OptWithLine};
 pub use crate::rustc_stderr::Level;

--- a/src/per_test_config.rs
+++ b/src/per_test_config.rs
@@ -386,24 +386,21 @@ impl TestConfig<'_> {
                 };
                 extra_args.extend(
                     build_manager
-                        .build(
-                            Build::Aux {
-                                aux_file: strip_path_prefix(
-                                    &aux_file.canonicalize().map_err(|err| Errored {
-                                        command: Command::new(format!(
-                                            "canonicalizing path `{}`",
-                                            aux_file.display()
-                                        )),
-                                        errors: vec![],
-                                        stderr: err.to_string().into_bytes(),
-                                        stdout: vec![],
-                                    })?,
-                                    &std::env::current_dir().unwrap(),
-                                )
-                                .collect(),
-                            },
-                            &self.config,
-                        )
+                        .build(Build::Aux {
+                            aux_file: strip_path_prefix(
+                                &aux_file.canonicalize().map_err(|err| Errored {
+                                    command: Command::new(format!(
+                                        "canonicalizing path `{}`",
+                                        aux_file.display()
+                                    )),
+                                    errors: vec![],
+                                    stderr: err.to_string().into_bytes(),
+                                    stdout: vec![],
+                                })?,
+                                &std::env::current_dir().unwrap(),
+                            )
+                            .collect(),
+                        })
                         .map_err(
                             |Errored {
                                  command,

--- a/src/per_test_config.rs
+++ b/src/per_test_config.rs
@@ -11,7 +11,7 @@ use std::process::{Command, Output};
 use spanned::Spanned;
 
 use crate::custom_flags::Flag;
-use crate::dependencies::{Build, BuildManager};
+use crate::dependencies::{AuxBuilder, BuildManager};
 pub use crate::parser::{Comments, Condition, Revisioned};
 use crate::parser::{ErrorMatch, ErrorMatchKind, OptWithLine};
 pub use crate::rustc_stderr::Level;
@@ -386,7 +386,7 @@ impl TestConfig<'_> {
                 };
                 extra_args.extend(
                     build_manager
-                        .build(Build::Aux {
+                        .build(AuxBuilder {
                             aux_file: strip_path_prefix(
                                 &aux_file.canonicalize().map_err(|err| Errored {
                                     command: Command::new(format!(

--- a/src/per_test_config.rs
+++ b/src/per_test_config.rs
@@ -12,7 +12,7 @@ use std::process::{Command, Output};
 
 use spanned::{Span, Spanned};
 
-use crate::core::Flag;
+use crate::custom_flags::Flag;
 use crate::dependencies::{Build, BuildManager};
 pub use crate::parser::{Comments, Condition, Revisioned};
 use crate::parser::{ErrorMatch, ErrorMatchKind, OptWithLine};
@@ -462,7 +462,7 @@ impl TestConfig<'_> {
         Ok(TestOk::Ok)
     }
 
-    fn run_test_binary(&self, mut cmd: Command, exit_code: i32) -> TestResult {
+    pub(crate) fn run_test_binary(&self, mut cmd: Command, exit_code: i32) -> TestResult {
         let revision = self.extension("run");
         let config = TestConfig {
             config: self.config.clone(),
@@ -660,25 +660,5 @@ impl TestConfig<'_> {
 
     fn find_one_custom(&self, arg: &str) -> Result<OptWithLine<&dyn Flag>, Errored> {
         self.find_one(arg, |r| r.custom.get(arg).map(|s| s.as_ref()).into())
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
-pub(crate) struct Run {
-    pub exit_code: i32,
-}
-
-impl Flag for Run {
-    fn clone_inner(&self) -> Box<dyn Flag> {
-        Box::new(*self)
-    }
-    fn post_test_action(
-        &self,
-        config: &TestConfig<'_>,
-        cmd: Command,
-        _output: &Output,
-    ) -> Result<Option<Command>, Errored> {
-        config.run_test_binary(cmd, self.exit_code)?;
-        Ok(None)
     }
 }

--- a/src/per_test_config.rs
+++ b/src/per_test_config.rs
@@ -78,7 +78,7 @@ impl TestConfig<'_> {
     fn apply_custom(&self, cmd: &mut Command) {
         for rev in self.comments.for_revision(self.revision) {
             for flag in rev.custom.values() {
-                flag.content.apply(cmd);
+                flag.content.apply(cmd, self);
             }
         }
     }

--- a/src/per_test_config.rs
+++ b/src/per_test_config.rs
@@ -11,8 +11,8 @@ use std::process::{Command, Output};
 use spanned::Spanned;
 
 use crate::aux_builds::AuxBuilder;
+use crate::build_manager::BuildManager;
 use crate::custom_flags::Flag;
-use crate::dependencies::BuildManager;
 pub use crate::parser::{Comments, Condition, Revisioned};
 use crate::parser::{ErrorMatch, ErrorMatchKind, OptWithLine};
 pub use crate::rustc_stderr::Level;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -25,6 +25,7 @@ macro_rules! config {
             path,
             comments: &comments,
             revision: "",
+            aux_dir: Path::new("unused_doesnt_exist"),
         };
     };
 }

--- a/tests/integrations/basic-fail/Cargo.stdout
+++ b/tests/integrations/basic-fail/Cargo.stdout
@@ -519,7 +519,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests_bless/aux_proc_macro_no_main.rs
-command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "--extern" "the_proc_macro=$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary/libthe_proc_macro.so" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary" "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--edition" "2021" "--extern" "the_proc_macro=$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary/libthe_proc_macro.so" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary"
 
 error: there were 1 unmatched diagnostics
  --> tests/actual_tests_bless/aux_proc_macro_no_main.rs:7:8

--- a/tests/integrations/basic-fail/Cargo.stdout
+++ b/tests/integrations/basic-fail/Cargo.stdout
@@ -519,7 +519,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests_bless/aux_proc_macro_no_main.rs
-command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--edition" "2021" "--extern" "the_proc_macro=$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary/libthe_proc_macro.so" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary"
+command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--extern" "the_proc_macro=$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary/libthe_proc_macro.so" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary" "--edition" "2021"
 
 error: there were 1 unmatched diagnostics
  --> tests/actual_tests_bless/aux_proc_macro_no_main.rs:7:8

--- a/tests/integrations/basic-fail/Cargo.stdout
+++ b/tests/integrations/basic-fail/Cargo.stdout
@@ -519,7 +519,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests_bless/aux_proc_macro_no_main.rs
-command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--extern" "the_proc_macro=$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary/libthe_proc_macro.so" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary" "--out-dir" "$TMP "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--edition" "2021"
+command: "rustc" "--error-format=json" "--crate-type=lib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--out-dir" "$TMP "--extern" "the_proc_macro=$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary/libthe_proc_macro.so" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/tests/actual_tests_bless/auxiliary" "tests/actual_tests_bless/aux_proc_macro_no_main.rs" "--edition" "2021"
 
 error: there were 1 unmatched diagnostics
  --> tests/actual_tests_bless/aux_proc_macro_no_main.rs:7:8

--- a/tests/integrations/basic-fail/tests/ui_tests_bless.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_bless.rs
@@ -33,7 +33,7 @@ fn main() -> ui_test::color_eyre::Result<()> {
             .comment_defaults
             .base()
             .custom
-            .insert("rustfix", Spanned::dummy(Box::new(rustfix)));
+            .insert("rustfix", Spanned::dummy(vec![Box::new(rustfix)]));
 
         // hide binaries generated for successfully passing tests
         let tmp_dir = tempfile::tempdir_in(path)?;

--- a/tests/integrations/basic-fail/tests/ui_tests_bless.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_bless.rs
@@ -1,4 +1,4 @@
-use ui_test::{spanned::Spanned, *};
+use ui_test::{custom_flags::rustfix::RustfixMode, spanned::Spanned, *};
 
 fn main() -> ui_test::color_eyre::Result<()> {
     for (mode, rustfix) in [


### PR DESCRIPTION
The fact that this works makes me think that https://github.com/oli-obk/ui_test/issues/186 can now be implemented, even outside of this crate