### PR TITLE
Fix redundant imports

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use spanned::Spanned;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 
-use ui_test::color_eyre::Result;
-use ui_test::{filter::Match, spanned::Spanned, *};
+use ui_test::{spanned::Spanned, *};
 
 fn main() -> Result<()> {
     let path = Path::new(file!()).parent().unwrap();


### PR DESCRIPTION
This removes some redundant imports that newer versions of rustc complain about.
