### PR TITLE
Create multiple `.fixed` files for diagnostics with multiple suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Split up `Revisioned::mode` into `Revisioned::exit_status` and `Revisioned::require_annotations`
 * `Config::output_conflict_handling` is now `Error` instead of `Bless`
+* Rustfix tests now create multiple `.fixed` files if diagnostics contain multiple suggestions
 * updated `prettydiff` from 0.6.4 to 0.7.0, which drops `ansi_term` and `winapi*` deps.
 
 ### Removed

--- a/src/custom_flags.rs
+++ b/src/custom_flags.rs
@@ -34,15 +34,15 @@ pub trait Flag: Send + Sync + UnwindSafe + RefUnwindSafe + std::fmt::Debug {
     }
 
     /// Run an action after a test is finished.
-    /// Returns `None` if no action was taken.
+    /// Returns an empty [`Vec`] if no action was taken.
     fn post_test_action(
         &self,
         _config: &TestConfig<'_>,
         _cmd: &mut Command,
         _output: &Output,
         _build_manager: &BuildManager<'_>,
-    ) -> Result<Option<TestRun>, Errored> {
-        Ok(None)
+    ) -> Result<Vec<TestRun>, Errored> {
+        Ok(Vec::new())
     }
 
     /// Whether the flag gets overridden by the same flag in revisions.

--- a/src/custom_flags/run.rs
+++ b/src/custom_flags/run.rs
@@ -8,8 +8,8 @@ use std::{
 };
 
 use crate::{
-    build_manager::BuildManager, display, per_test_config::TestConfig, test_result::TestRun, Error,
-    Errored, TestOk,
+    build_manager::BuildManager, display, per_test_config::TestConfig, Error, Errored, TestOk,
+    TestRun,
 };
 
 use super::Flag;
@@ -33,7 +33,7 @@ impl Flag for Run {
         cmd: &mut Command,
         _output: &Output,
         _build_manager: &BuildManager<'_>,
-    ) -> Result<Option<TestRun>, Errored> {
+    ) -> Result<Vec<TestRun>, Errored> {
         let exit_code = self.exit_code;
         let revision = config.extension("run");
         let config = TestConfig {
@@ -80,7 +80,8 @@ impl Flag for Run {
                 },
             })
         }
-        Ok(Some(TestRun {
+
+        Ok(vec![TestRun {
             result: if errors.is_empty() {
                 Ok(TestOk::Ok)
             } else {
@@ -92,7 +93,7 @@ impl Flag for Run {
                 })
             },
             status: config.status,
-        }))
+        }])
     }
 }
 

--- a/src/custom_flags/rustfix.rs
+++ b/src/custom_flags/rustfix.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::HashSet,
+    path::Path,
     process::{Command, Output},
 };
 
@@ -57,79 +58,15 @@ impl Flag for RustfixMode {
         };
         let output = output.clone();
         let no_run_rustfix = config.find_one_custom("no-rustfix")?;
-        let fixed_code = (no_run_rustfix.is_none() && global_rustfix.enabled())
-            .then_some(())
-            .and_then(|()| {
-                let suggestions = std::str::from_utf8(&output.stderr)
-                    .unwrap()
-                    .lines()
-                    .flat_map(|line| {
-                        if !line.starts_with('{') {
-                            return vec![];
-                        }
-                        rustfix::get_suggestions_from_json(
-                            line,
-                            &HashSet::new(),
-                            if global_rustfix == RustfixMode::Everything {
-                                rustfix::Filter::Everything
-                            } else {
-                                rustfix::Filter::MachineApplicableOnly
-                            },
-                        )
-                        .unwrap_or_else(|err| {
-                            panic!("could not deserialize diagnostics json for rustfix {err}:{line}")
-                        })
-                    })
-                    .collect::<Vec<_>>();
-                if suggestions.is_empty() {
-                    None
-                } else {
-                    let path_str = display(config.status.path());
-                    for sugg in &suggestions {
-                        for snip in &sugg.snippets {
-                            let file_name = snip.file_name.replace('\\', "/");
-                            if file_name != path_str {
-                                return Some(Err(anyhow::anyhow!("cannot apply suggestions for `{file_name}` since main file is `{path_str}`. Please use `//@no-rustfix` to disable rustfix")));
-                            }
-                        }
-                    }
-                    Some(rustfix::apply_suggestions(
-                        &std::fs::read_to_string(config.status.path()).unwrap(),
-                        &suggestions,
-                    ).map_err(|e| e.into()))
-                }
-            })
-            .transpose()
-            .map_err(|err| Errored {
+        let fixed_code = if no_run_rustfix.is_none() && global_rustfix.enabled() {
+            fix(&output.stderr, config.status.path(), global_rustfix).map_err(|err| Errored {
                 command: format!("rustfix {}", display(config.status.path())),
                 errors: vec![Error::Rustfix(err)],
                 stderr: output.stderr,
                 stdout: output.stdout,
-            })?;
-
-        let rustfix_comments = Comments {
-            revisions: None,
-            revisioned: std::iter::once((
-                vec![],
-                Revisioned {
-                    span: Span::default(),
-                    ignore: vec![],
-                    only: vec![],
-                    stderr_per_bitwidth: false,
-                    compile_flags: config.collect(|r| r.compile_flags.iter().cloned()),
-                    env_vars: config.collect(|r| r.env_vars.iter().cloned()),
-                    normalize_stderr: vec![],
-                    normalize_stdout: vec![],
-                    error_in_other_files: vec![],
-                    error_matches: vec![],
-                    require_annotations_for_level: Default::default(),
-                    diagnostic_code_prefix: OptWithLine::new(String::new(), Span::default()),
-                    custom: config.comments().flat_map(|r| r.custom.clone()).collect(),
-                    exit_status: OptWithLine::new(0, Span::default()),
-                    require_annotations: OptWithLine::default(),
-                },
-            ))
-            .collect(),
+            })?
+        } else {
+            None
         };
 
         let run = fixed_code.is_some();
@@ -141,16 +78,6 @@ impl Flag for RustfixMode {
             &mut errors,
             "fixed",
         );
-        // picking the crate name from the file name is problematic when `.revision_name` is inserted,
-        // so we compute it here before replacing the path.
-        let crate_name = config
-            .status
-            .path()
-            .file_stem()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .replace('-', "_");
 
         if !errors.is_empty() {
             return Ok(Some(TestRun {
@@ -168,42 +95,128 @@ impl Flag for RustfixMode {
             return Ok(None);
         }
 
-        let config = TestConfig {
-            config: config.config.clone(),
-            comments: &rustfix_comments,
-            aux_dir: config.aux_dir,
-            status: config.status.for_path(&rustfix_path),
-        };
+        compile_fixed(config, build_manager, &rustfix_path)
+    }
+}
 
-        let mut cmd = config.build_command(build_manager)?;
-        cmd.arg("--crate-name").arg(crate_name);
-        let output = cmd.output().unwrap();
-        if output.status.success() {
-            Ok(Some(TestRun {
-                result: Ok(TestOk::Ok),
-                status: config.status,
-            }))
-        } else {
-            let diagnostics = config.process(&output.stderr);
-            Err(Errored {
-                command: format!("{cmd:?}"),
-                errors: vec![Error::ExitStatus {
-                    expected: 0,
-                    status: output.status,
-                    reason: Spanned::new(
-                        "after rustfix is applied, all errors should be gone, but weren't".into(),
-                        diagnostics
-                            .messages
-                            .iter()
-                            .flatten()
-                            .chain(diagnostics.messages_from_unknown_file_or_line.iter())
-                            .find_map(|message| message.line_col.clone())
-                            .unwrap_or_default(),
-                    ),
-                }],
-                stderr: diagnostics.rendered,
-                stdout: output.stdout,
+fn fix(stderr: &[u8], path: &Path, global_rustfix: RustfixMode) -> anyhow::Result<Option<String>> {
+    let suggestions = std::str::from_utf8(stderr)
+        .unwrap()
+        .lines()
+        .flat_map(|line| {
+            if !line.starts_with('{') {
+                return vec![];
+            }
+            rustfix::get_suggestions_from_json(
+                line,
+                &HashSet::new(),
+                if global_rustfix == RustfixMode::Everything {
+                    rustfix::Filter::Everything
+                } else {
+                    rustfix::Filter::MachineApplicableOnly
+                },
+            )
+            .unwrap_or_else(|err| {
+                panic!("could not deserialize diagnostics json for rustfix {err}:{line}")
             })
+        })
+        .collect::<Vec<_>>();
+    if suggestions.is_empty() {
+        Ok(None)
+    } else {
+        let path_str = display(path);
+        for sugg in &suggestions {
+            for snip in &sugg.snippets {
+                let file_name = snip.file_name.replace('\\', "/");
+                anyhow::ensure!(
+                    file_name == path_str,
+                    "cannot apply suggestions for `{file_name}` since main file is `{path_str}`. Please use `//@no-rustfix` to disable rustfix",
+                )
+            }
         }
+        Ok(Some(rustfix::apply_suggestions(
+            &std::fs::read_to_string(path).unwrap(),
+            &suggestions,
+        )?))
+    }
+}
+
+fn compile_fixed(
+    config: &TestConfig,
+    build_manager: &BuildManager<'_>,
+    rustfix_path: &Path,
+) -> Result<Option<TestRun>, Errored> {
+    // picking the crate name from the file name is problematic when `.revision_name` is inserted,
+    // so we compute it here before replacing the path.
+    let crate_name = config
+        .status
+        .path()
+        .file_stem()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .replace('-', "_");
+
+    let rustfix_comments = Comments {
+        revisions: None,
+        revisioned: std::iter::once((
+            vec![],
+            Revisioned {
+                span: Span::default(),
+                ignore: vec![],
+                only: vec![],
+                stderr_per_bitwidth: false,
+                compile_flags: config.collect(|r| r.compile_flags.iter().cloned()),
+                env_vars: config.collect(|r| r.env_vars.iter().cloned()),
+                normalize_stderr: vec![],
+                normalize_stdout: vec![],
+                error_in_other_files: vec![],
+                error_matches: vec![],
+                require_annotations_for_level: Default::default(),
+                diagnostic_code_prefix: OptWithLine::new(String::new(), Span::default()),
+                custom: config.comments().flat_map(|r| r.custom.clone()).collect(),
+                exit_status: OptWithLine::new(0, Span::default()),
+                require_annotations: OptWithLine::default(),
+            },
+        ))
+        .collect(),
+    };
+
+    let fixed_config = TestConfig {
+        config: config.config.clone(),
+        comments: &rustfix_comments,
+        aux_dir: config.aux_dir,
+        status: config.status.for_path(&rustfix_path),
+    };
+
+    let mut cmd = fixed_config.build_command(build_manager)?;
+    cmd.arg("--crate-name").arg(crate_name);
+    let output = cmd.output().unwrap();
+    if output.status.success() {
+        Ok(Some(TestRun {
+            result: Ok(TestOk::Ok),
+            status: fixed_config.status,
+        }))
+    } else {
+        let diagnostics = fixed_config.process(&output.stderr);
+        Err(Errored {
+            command: format!("{cmd:?}"),
+            errors: vec![Error::ExitStatus {
+                expected: 0,
+                status: output.status,
+                reason: Spanned::new(
+                    "after rustfix is applied, all errors should be gone, but weren't".into(),
+                    diagnostics
+                        .messages
+                        .iter()
+                        .flatten()
+                        .chain(diagnostics.messages_from_unknown_file_or_line.iter())
+                        .find_map(|message| message.line_col.clone())
+                        .unwrap_or_default(),
+                ),
+            }],
+            stderr: diagnostics.rendered,
+            stdout: output.stdout,
+        })
     }
 }

--- a/tests/integrations/basic-fail/Cargo.stdout
+++ b/tests/integrations/basic-fail/Cargo.stdout
@@ -498,9 +498,12 @@ tests/actual_tests_bless/revisions_same_everywhere.rs (revision `foo`) ... ok
 tests/actual_tests_bless/revisions_same_everywhere.rs (revision `bar`) ... ok
 tests/actual_tests_bless/run_panic.rs (revision `run`) ... ok
 tests/actual_tests_bless/run_panic.rs ... ok
-tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `a`) ... FAILED
-tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `b`) ... FAILED
-tests/actual_tests_bless/rustfix-fail.rs ... FAILED
+tests/actual_tests_bless/rustfix-fail-revisions.a.fixed (revision `a`) ... FAILED
+tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `a`) ... ok
+tests/actual_tests_bless/rustfix-fail-revisions.b.fixed (revision `b`) ... FAILED
+tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `b`) ... ok
+tests/actual_tests_bless/rustfix-fail.fixed ... FAILED
+tests/actual_tests_bless/rustfix-fail.rs ... ok
 tests/actual_tests_bless/unknown_revision.rs ... FAILED
 tests/actual_tests_bless/unknown_revision2.rs ... FAILED
 tests/actual_tests_bless/wrong_diagnostic_code.rs ... FAILED
@@ -842,11 +845,11 @@ full stdout:
 
 
 
-FAILED TEST: tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `a`)
+FAILED TEST: tests/actual_tests_bless/rustfix-fail-revisions.a.fixed (revision `a`)
 command: "rustc" "--error-format=json" "--out-dir" "$TMP "tests/actual_tests_bless/rustfix-fail-revisions.a.fixed" "--cfg=a" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--edition" "2021" "--crate-name" "rustfix_fail_revisions"
 
 error: test got exit status: 1, but expected 0
- --> tests/actual_tests_bless/rustfix-fail-revisions.rs:2:9
+ --> tests/actual_tests_bless/rustfix-fail-revisions.a.fixed:2:9
   |
 2 | #![deny(warnings)]
   |         ^^^^^^^^ after rustfix is applied, all errors should be gone, but weren't
@@ -873,11 +876,11 @@ full stdout:
 
 
 
-FAILED TEST: tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `b`)
+FAILED TEST: tests/actual_tests_bless/rustfix-fail-revisions.b.fixed (revision `b`)
 command: "rustc" "--error-format=json" "--out-dir" "$TMP "tests/actual_tests_bless/rustfix-fail-revisions.b.fixed" "--cfg=b" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--edition" "2021" "--crate-name" "rustfix_fail_revisions"
 
 error: test got exit status: 1, but expected 0
- --> tests/actual_tests_bless/rustfix-fail-revisions.rs:2:9
+ --> tests/actual_tests_bless/rustfix-fail-revisions.b.fixed:2:9
   |
 2 | #![deny(warnings)]
   |         ^^^^^^^^ after rustfix is applied, all errors should be gone, but weren't
@@ -904,11 +907,11 @@ full stdout:
 
 
 
-FAILED TEST: tests/actual_tests_bless/rustfix-fail.rs
+FAILED TEST: tests/actual_tests_bless/rustfix-fail.fixed
 command: "rustc" "--error-format=json" "--out-dir" "$TMP "tests/actual_tests_bless/rustfix-fail.fixed" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--edition" "2021" "--crate-name" "rustfix_fail"
 
 error: test got exit status: 1, but expected 0
- --> tests/actual_tests_bless/rustfix-fail.rs:1:9
+ --> tests/actual_tests_bless/rustfix-fail.fixed:1:9
   |
 1 | #![deny(warnings)]
   |         ^^^^^^^^ after rustfix is applied, all errors should be gone, but weren't
@@ -1034,22 +1037,65 @@ FAILURES:
     tests/actual_tests_bless/revisioned_executable.rs (revision panic.run)
     tests/actual_tests_bless/revisioned_executable_panic.rs (revision run.run)
     tests/actual_tests_bless/revisions_bad.rs (revision bar)
-    tests/actual_tests_bless/rustfix-fail-revisions.rs (revision a)
-    tests/actual_tests_bless/rustfix-fail-revisions.rs (revision b)
-    tests/actual_tests_bless/rustfix-fail.rs
+    tests/actual_tests_bless/rustfix-fail-revisions.a.fixed (revision a)
+    tests/actual_tests_bless/rustfix-fail-revisions.b.fixed (revision b)
+    tests/actual_tests_bless/rustfix-fail.fixed
     tests/actual_tests_bless/unknown_revision.rs
     tests/actual_tests_bless/unknown_revision2.rs
     tests/actual_tests_bless/wrong_diagnostic_code.rs
 
-test result: FAIL. 22 failed; 21 passed; 3 ignored;
+test result: FAIL. 22 failed; 24 passed; 3 ignored;
 
 Building dependencies ... ok
 tests/actual_tests_bless_yolo/revisions_bad.rs (revision `foo`) ... ok
 tests/actual_tests_bless_yolo/revisions_bad.rs (revision `bar`) ... ok
 tests/actual_tests_bless_yolo/rustfix-maybe-incorrect.fixed ... ok
 tests/actual_tests_bless_yolo/rustfix-maybe-incorrect.rs ... ok
+tests/actual_tests_bless_yolo/rustfix-multiple-fail.1.fixed ... ok
+tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed ... FAILED
+tests/actual_tests_bless_yolo/rustfix-multiple-fail.3.fixed ... ok
+tests/actual_tests_bless_yolo/rustfix-multiple-fail.rs ... ok
 
-test result: ok. 4 passed;
+FAILED TEST: tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed
+command: "rustc" "--error-format=json" "--out-dir" "$TMP "tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--edition" "2021" "--crate-name" "rustfix_multiple_fail"
+
+error: test got exit status: 1, but expected 0
+ --> tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed:1:8
+  |
+1 | pub fn f(_: &i32) -> &i32 {
+  |        ^ after rustfix is applied, all errors should be gone, but weren't
+  |
+
+full stderr:
+error[E0308]: mismatched types
+ --> tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed:7:7
+  |
+7 |     f(1);
+  |     - ^ expected `&i32`, found integer
+  |     |
+  |     arguments to this function are incorrect
+  |
+note: function defined here
+ --> tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed:1:8
+  |
+1 | pub fn f(_: &i32) -> &i32 {
+  |        ^ -------
+help: consider borrowing here
+  |
+7 |     f(&1);
+  |       +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.
+
+full stdout:
+
+
+FAILURES:
+    tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed
+
+test result: FAIL. 1 failed; 7 passed;
 
 tests/actual_tests/bad_pattern.rs ... FAILED
 tests/actual_tests/executable.rs ... FAILED

--- a/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/rustfix-multiple-fail.1.fixed
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/rustfix-multiple-fail.1.fixed
@@ -1,0 +1,8 @@
+pub fn f(_: i32) -> &'static i32 {
+    //~^ ERROR: missing lifetime
+    unimplemented!()
+}
+
+fn main() {
+    f(1);
+}

--- a/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed
@@ -1,0 +1,8 @@
+pub fn f(_: &i32) -> &i32 {
+    //~^ ERROR: missing lifetime
+    unimplemented!()
+}
+
+fn main() {
+    f(1);
+}

--- a/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/rustfix-multiple-fail.3.fixed
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/rustfix-multiple-fail.3.fixed
@@ -1,0 +1,8 @@
+pub fn f(_: i32) -> i32 {
+    //~^ ERROR: missing lifetime
+    unimplemented!()
+}
+
+fn main() {
+    f(1);
+}

--- a/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/rustfix-multiple-fail.rs
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/rustfix-multiple-fail.rs
@@ -1,0 +1,8 @@
+pub fn f(_: i32) -> &i32 {
+    //~^ ERROR: missing lifetime
+    unimplemented!()
+}
+
+fn main() {
+    f(1);
+}

--- a/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/rustfix-multiple-fail.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless_yolo/rustfix-multiple-fail.stderr
@@ -1,0 +1,24 @@
+error[E0106]: missing lifetime specifier
+ --> tests/actual_tests_bless_yolo/rustfix-multiple-fail.rs:1:21
+  |
+1 | pub fn f(_: i32) -> &i32 {
+  |                     ^ expected named lifetime parameter
+  |
+  = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
+  |
+1 | pub fn f(_: i32) -> &'static i32 {
+  |                      +++++++
+help: instead, you are more likely to want to change the argument to be borrowed...
+  |
+1 | pub fn f(_: &i32) -> &i32 {
+  |             +
+help: ...or alternatively, you might want to return an owned value
+  |
+1 - pub fn f(_: i32) -> &i32 {
+1 + pub fn f(_: i32) -> i32 {
+  |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0106`.

--- a/tests/integrations/basic-fail/tests/ui_tests_bless.rs
+++ b/tests/integrations/basic-fail/tests/ui_tests_bless.rs
@@ -46,18 +46,13 @@ fn main() -> ui_test::color_eyre::Result<()> {
         config.stdout_filter("in ([0-9]m )?[0-9\\.]+s", "");
         config.stderr_filter(r"[^ ]*/\.?cargo/registry/.*/", "$$CARGO_REGISTRY");
         config.path_stderr_filter(&std::path::Path::new(path), "$DIR");
-        let result = run_tests_generic(
+        let _ = run_tests_generic(
             vec![config],
             default_file_filter,
             default_per_file_config,
             // Avoid github actions, as these would end up showing up in `Cargo.stderr`
             status_emitter::Text::verbose(),
         );
-        match (&result, rustfix) {
-            (Ok(_), RustfixMode::Everything) => {}
-            (Err(_), RustfixMode::MachineApplicable) => {}
-            _ => panic!("invalid mode/result combo: {rustfix:?}: {result:?}"),
-        }
     }
     Ok(())
 }

--- a/tests/integrations/basic/Cargo.stdout
+++ b/tests/integrations/basic/Cargo.stdout
@@ -33,13 +33,16 @@ tests/actual_tests/mac_span.rs ... ok
 tests/actual_tests/match_diagnostic_code.fixed ... ok
 tests/actual_tests/match_diagnostic_code.rs ... ok
 tests/actual_tests/no_rustfix.rs ... ok
+tests/actual_tests/rustfix-multiple.1.fixed ... ok
+tests/actual_tests/rustfix-multiple.2.fixed ... ok
+tests/actual_tests/rustfix-multiple.rs ... ok
 tests/actual_tests/stdin.rs (revision `run`) ... ok
 tests/actual_tests/stdin.rs ... ok
 tests/actual_tests/unicode.rs ... ok
 tests/actual_tests/windows_paths.rs ... ok
 tests/actual_tests/subdir/aux_proc_macro.rs ... ok
 
-test result: ok. 27 passed;
+test result: ok. 30 passed;
 
 
 running 0 tests

--- a/tests/integrations/basic/tests/actual_tests/rustfix-multiple.1.fixed
+++ b/tests/integrations/basic/tests/actual_tests/rustfix-multiple.1.fixed
@@ -1,0 +1,9 @@
+pub fn f() -> usize {
+    1
+}
+
+pub fn g() {
+    f(); //~ ERROR: mismatched types
+}
+
+fn main() {}

--- a/tests/integrations/basic/tests/actual_tests/rustfix-multiple.2.fixed
+++ b/tests/integrations/basic/tests/actual_tests/rustfix-multiple.2.fixed
@@ -1,0 +1,9 @@
+pub fn f() -> usize {
+    1
+}
+
+pub fn g() -> usize {
+    f() //~ ERROR: mismatched types
+}
+
+fn main() {}

--- a/tests/integrations/basic/tests/actual_tests/rustfix-multiple.rs
+++ b/tests/integrations/basic/tests/actual_tests/rustfix-multiple.rs
@@ -1,0 +1,9 @@
+pub fn f() -> usize {
+    1
+}
+
+pub fn g() {
+    f() //~ ERROR: mismatched types
+}
+
+fn main() {}

--- a/tests/integrations/basic/tests/actual_tests/rustfix-multiple.stderr
+++ b/tests/integrations/basic/tests/actual_tests/rustfix-multiple.stderr
@@ -1,0 +1,18 @@
+error[E0308]: mismatched types
+ --> tests/actual_tests/rustfix-multiple.rs:6:5
+  |
+6 |     f()
+  |     ^^^ expected `()`, found `usize`
+  |
+help: consider using a semicolon here
+  |
+6 |     f();
+  |        +
+help: try adding a return type
+  |
+5 | pub fn g() -> usize {
+  |            ++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Some clippy tests disable rustfix because they produce multiple alternative suggestions e.g. [`join_absolute_paths`](https://github.com/rust-lang/rust-clippy/blob/29cc5c691c574b54b2fcfed51c22f8bb51110919/tests/ui/join_absolute_paths.stderr). This PR allows there to be a `.fixed` file per alternative suggestion, in that example `join_absolute_paths.1.fixed` and `join_absolute_paths.2.fixed`

There are some lints that produce multiple suggestions that are intended to be combined e.g.

```
error: this binding can be a slice pattern to avoid indexing
  --> tests/ui/index_refutable_slice/if_let_slice_binding.rs:21:17
   |
LL |     if let Some(slice) = slice {
   |                 ^^^^^
   |
help: try using a slice pattern here
   |
LL |     if let Some([slice_0, ..]) = slice {
   |                 ~~~~~~~~~~~~~
help: and replace the index expressions here
   |
LL |         println!("{}", slice_0);
   |                        ~~~~~~~
```

These would have to use `//@no-rustfix` for now, but I think moving them to multipart suggestions is correct in the long run