### PR TITLE
Silence subtests in `Flag`s

### DIFF
--- a/src/custom_flags.rs
+++ b/src/custom_flags.rs
@@ -5,9 +5,7 @@ use std::{
     process::{Command, Output},
 };
 
-use crate::{
-    build_manager::BuildManager, per_test_config::TestConfig, test_result::TestRun, Config, Errored,
-};
+use crate::{build_manager::BuildManager, per_test_config::TestConfig, Config, Errored};
 
 #[cfg(feature = "rustc")]
 pub mod run;
@@ -34,15 +32,14 @@ pub trait Flag: Send + Sync + UnwindSafe + RefUnwindSafe + std::fmt::Debug {
     }
 
     /// Run an action after a test is finished.
-    /// Returns an empty [`Vec`] if no action was taken.
     fn post_test_action(
         &self,
         _config: &TestConfig<'_>,
         _cmd: &mut Command,
         _output: &Output,
         _build_manager: &BuildManager<'_>,
-    ) -> Result<Vec<TestRun>, Errored> {
-        Ok(Vec::new())
+    ) -> Result<(), Errored> {
+        Ok(())
     }
 
     /// Whether the flag gets overridden by the same flag in revisions.

--- a/src/custom_flags/run.rs
+++ b/src/custom_flags/run.rs
@@ -7,10 +7,7 @@ use std::{
     process::{Command, Output},
 };
 
-use crate::{
-    build_manager::BuildManager, display, per_test_config::TestConfig, Error, Errored, TestOk,
-    TestRun,
-};
+use crate::{build_manager::BuildManager, display, per_test_config::TestConfig, Error, Errored};
 
 use super::Flag;
 
@@ -33,7 +30,7 @@ impl Flag for Run {
         cmd: &mut Command,
         _output: &Output,
         _build_manager: &BuildManager<'_>,
-    ) -> Result<Vec<TestRun>, Errored> {
+    ) -> Result<(), Errored> {
         let exit_code = self.exit_code;
         let revision = config.extension("run");
         let config = TestConfig {
@@ -81,19 +78,16 @@ impl Flag for Run {
             })
         }
 
-        Ok(vec![TestRun {
-            result: if errors.is_empty() {
-                Ok(TestOk::Ok)
-            } else {
-                Err(Errored {
-                    command: format!("{exe:?}"),
-                    errors,
-                    stderr: output.stderr,
-                    stdout: output.stdout,
-                })
-            },
-            status: config.status,
-        }])
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(Errored {
+                command: format!("{exe:?}"),
+                errors,
+                stderr: output.stderr,
+                stdout: output.stdout,
+            })
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,7 @@ fn parse_and_test_file(
             status,
         };
 
-        let result = test_config.run_test(build_manager, &mut runs);
+        let result = test_config.run_test(build_manager);
         runs.push(TestRun {
             result,
             status: test_config.status,

--- a/src/per_test_config.rs
+++ b/src/per_test_config.rs
@@ -17,9 +17,9 @@ pub use crate::diagnostics::Level;
 use crate::diagnostics::{Diagnostics, Message};
 pub use crate::parser::{Comments, Condition, Revisioned};
 use crate::parser::{ErrorMatch, ErrorMatchKind, OptWithLine};
-use crate::status_emitter::TestStatus;
+use crate::status_emitter::{SilentStatus, TestStatus};
 use crate::test_result::{Errored, TestOk, TestResult};
-use crate::{core::strip_path_prefix, Config, Error, Errors, OutputConflictHandling, TestRun};
+use crate::{core::strip_path_prefix, Config, Error, Errors, OutputConflictHandling};
 
 /// All information needed to run a single test
 pub struct TestConfig<'a> {
@@ -395,11 +395,7 @@ impl TestConfig<'_> {
         Ok(())
     }
 
-    pub(crate) fn run_test(
-        &mut self,
-        build_manager: &BuildManager<'_>,
-        runs: &mut Vec<TestRun>,
-    ) -> TestResult {
+    pub(crate) fn run_test(&mut self, build_manager: &BuildManager<'_>) -> TestResult {
         self.patch_out_dir();
 
         let mut cmd = self.build_command(build_manager)?;
@@ -412,10 +408,19 @@ impl TestConfig<'_> {
 
         let output = self.check_test_result(&cmd, output)?;
 
+        let silent = TestConfig {
+            config: self.config.clone(),
+            comments: self.comments,
+            aux_dir: self.aux_dir,
+            status: Box::new(SilentStatus {
+                revision: self.status.revision().to_string(),
+                path: self.status.path().to_path_buf(),
+            }),
+        };
         for rev in self.comments() {
             for custom in rev.custom.values() {
                 for flag in &custom.content {
-                    runs.extend(flag.post_test_action(self, &mut cmd, &output, build_manager)?);
+                    flag.post_test_action(&silent, &mut cmd, &output, build_manager)?;
                 }
             }
         }

--- a/tests/integrations/basic-fail/Cargo.stdout
+++ b/tests/integrations/basic-fail/Cargo.stdout
@@ -5,8 +5,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 
 Building dependencies ... ok
 tests/actual_tests/bad_pattern.rs ... FAILED
-tests/actual_tests/executable.rs (revision `run`) ... FAILED
-tests/actual_tests/executable.rs ... ok
+tests/actual_tests/executable.rs ... FAILED
 tests/actual_tests/executable_compile_err.rs ... FAILED
 tests/actual_tests/exit_code_fail.rs ... FAILED
 tests/actual_tests/filters.rs ... FAILED
@@ -76,7 +75,7 @@ full stdout:
 
 
 
-FAILED TEST: tests/actual_tests/executable.rs (revision `run`)
+FAILED TEST: tests/actual_tests/executable.rs
 command: "$CMD"
 
 error: actual output differed from expected
@@ -437,7 +436,7 @@ full stdout:
 
 FAILURES:
     tests/actual_tests/bad_pattern.rs
-    tests/actual_tests/executable.rs (revision run)
+    tests/actual_tests/executable.rs
     tests/actual_tests/executable_compile_err.rs
     tests/actual_tests/exit_code_fail.rs
     tests/actual_tests/filters.rs
@@ -452,19 +451,17 @@ FAILURES:
     tests/actual_tests/touching_above_below.rs
     tests/actual_tests/touching_above_below_chain.rs
 
-test result: FAIL. 15 failed; 1 passed;
+test result: FAIL. 15 failed;
 
 Building dependencies ... ok
-tests/actual_tests_bless/abort.rs (revision `run`) ... FAILED
-tests/actual_tests_bless/abort.rs ... ok
+tests/actual_tests_bless/abort.rs ... FAILED
 tests/actual_tests_bless/aux_build_not_found.rs ... FAILED
 tests/actual_tests_bless/aux_proc_macro_misuse.rs ... FAILED
 Building aux file tests/actual_tests_bless/auxiliary/the_proc_macro.rs ... ok
 tests/actual_tests_bless/aux_proc_macro_no_main.rs ... FAILED
 tests/actual_tests_bless/compile_flags_quotes.rs ... FAILED
 tests/actual_tests_bless/compiletest-rs-command.rs ... FAILED
-tests/actual_tests_bless/failing_executable.rs (revision `run`) ... FAILED
-tests/actual_tests_bless/failing_executable.rs ... ok
+tests/actual_tests_bless/failing_executable.rs ... FAILED
 Building aux file tests/actual_tests_bless/auxiliary/foomp.rs ... ok
 tests/actual_tests_bless/foomp_aux.rs ... ok
 Building aux file tests/actual_tests_bless/auxiliary/nested.rs ... ok
@@ -476,13 +473,9 @@ tests/actual_tests_bless/non_top_level_configs.rs ... FAILED
 tests/actual_tests_bless/pass.rs ... ok
 tests/actual_tests_bless/pass_with_annotation.rs ... FAILED
 tests/actual_tests_bless/revised_revision.rs ... FAILED
-tests/actual_tests_bless/revisioned_executable.rs (revision `run.run`) ... ok
 tests/actual_tests_bless/revisioned_executable.rs (revision `run`) ... ok
-tests/actual_tests_bless/revisioned_executable.rs (revision `panic.run`) ... FAILED
-tests/actual_tests_bless/revisioned_executable.rs (revision `panic`) ... ok
-tests/actual_tests_bless/revisioned_executable_panic.rs (revision `run.run`) ... FAILED
-tests/actual_tests_bless/revisioned_executable_panic.rs (revision `run`) ... ok
-tests/actual_tests_bless/revisioned_executable_panic.rs (revision `panic.run`) ... ok
+tests/actual_tests_bless/revisioned_executable.rs (revision `panic`) ... FAILED
+tests/actual_tests_bless/revisioned_executable_panic.rs (revision `run`) ... FAILED
 tests/actual_tests_bless/revisioned_executable_panic.rs (revision `panic`) ... ok
 tests/actual_tests_bless/revisions.rs (revision `foo`) ... ok
 tests/actual_tests_bless/revisions.rs (revision `bar`) ... ok
@@ -496,19 +489,15 @@ tests/actual_tests_bless/revisions_multiple_per_annotation.rs (revision `foo`) .
 tests/actual_tests_bless/revisions_multiple_per_annotation.rs (revision `bar`) ... ok
 tests/actual_tests_bless/revisions_same_everywhere.rs (revision `foo`) ... ok
 tests/actual_tests_bless/revisions_same_everywhere.rs (revision `bar`) ... ok
-tests/actual_tests_bless/run_panic.rs (revision `run`) ... ok
 tests/actual_tests_bless/run_panic.rs ... ok
-tests/actual_tests_bless/rustfix-fail-revisions.a.fixed (revision `a`) ... FAILED
-tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `a`) ... ok
-tests/actual_tests_bless/rustfix-fail-revisions.b.fixed (revision `b`) ... FAILED
-tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `b`) ... ok
-tests/actual_tests_bless/rustfix-fail.fixed ... FAILED
-tests/actual_tests_bless/rustfix-fail.rs ... ok
+tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `a`) ... FAILED
+tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `b`) ... FAILED
+tests/actual_tests_bless/rustfix-fail.rs ... FAILED
 tests/actual_tests_bless/unknown_revision.rs ... FAILED
 tests/actual_tests_bless/unknown_revision2.rs ... FAILED
 tests/actual_tests_bless/wrong_diagnostic_code.rs ... FAILED
 
-FAILED TEST: tests/actual_tests_bless/abort.rs (revision `run`)
+FAILED TEST: tests/actual_tests_bless/abort.rs
 command: "$CMD"
 
 error: test got signal: 6 (SIGABRT), but expected 0
@@ -630,7 +619,7 @@ full stdout:
 
 
 
-FAILED TEST: tests/actual_tests_bless/failing_executable.rs (revision `run`)
+FAILED TEST: tests/actual_tests_bless/failing_executable.rs
 command: "$CMD"
 
 error: test got exit status: 101, but expected 0
@@ -782,7 +771,7 @@ full stdout:
 
 
 
-FAILED TEST: tests/actual_tests_bless/revisioned_executable.rs (revision `panic.run`)
+FAILED TEST: tests/actual_tests_bless/revisioned_executable.rs (revision `panic`)
 command: "$CMD"
 
 error: test got exit status: 0, but expected 101
@@ -794,7 +783,7 @@ full stdout:
 
 
 
-FAILED TEST: tests/actual_tests_bless/revisioned_executable_panic.rs (revision `run.run`)
+FAILED TEST: tests/actual_tests_bless/revisioned_executable_panic.rs (revision `run`)
 command: "$CMD"
 
 error: test got exit status: 101, but expected 0
@@ -845,11 +834,11 @@ full stdout:
 
 
 
-FAILED TEST: tests/actual_tests_bless/rustfix-fail-revisions.a.fixed (revision `a`)
+FAILED TEST: tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `a`)
 command: "rustc" "--error-format=json" "--out-dir" "$TMP "tests/actual_tests_bless/rustfix-fail-revisions.a.fixed" "--cfg=a" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--edition" "2021" "--crate-name" "rustfix_fail_revisions"
 
 error: test got exit status: 1, but expected 0
- --> tests/actual_tests_bless/rustfix-fail-revisions.a.fixed:2:9
+ --> tests/actual_tests_bless/rustfix-fail-revisions.rs:2:9
   |
 2 | #![deny(warnings)]
   |         ^^^^^^^^ after rustfix is applied, all errors should be gone, but weren't
@@ -876,11 +865,11 @@ full stdout:
 
 
 
-FAILED TEST: tests/actual_tests_bless/rustfix-fail-revisions.b.fixed (revision `b`)
+FAILED TEST: tests/actual_tests_bless/rustfix-fail-revisions.rs (revision `b`)
 command: "rustc" "--error-format=json" "--out-dir" "$TMP "tests/actual_tests_bless/rustfix-fail-revisions.b.fixed" "--cfg=b" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--edition" "2021" "--crate-name" "rustfix_fail_revisions"
 
 error: test got exit status: 1, but expected 0
- --> tests/actual_tests_bless/rustfix-fail-revisions.b.fixed:2:9
+ --> tests/actual_tests_bless/rustfix-fail-revisions.rs:2:9
   |
 2 | #![deny(warnings)]
   |         ^^^^^^^^ after rustfix is applied, all errors should be gone, but weren't
@@ -907,11 +896,11 @@ full stdout:
 
 
 
-FAILED TEST: tests/actual_tests_bless/rustfix-fail.fixed
+FAILED TEST: tests/actual_tests_bless/rustfix-fail.rs
 command: "rustc" "--error-format=json" "--out-dir" "$TMP "tests/actual_tests_bless/rustfix-fail.fixed" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--edition" "2021" "--crate-name" "rustfix_fail"
 
 error: test got exit status: 1, but expected 0
- --> tests/actual_tests_bless/rustfix-fail.fixed:1:9
+ --> tests/actual_tests_bless/rustfix-fail.rs:1:9
   |
 1 | #![deny(warnings)]
   |         ^^^^^^^^ after rustfix is applied, all errors should be gone, but weren't
@@ -1021,48 +1010,44 @@ full stdout:
 
 
 FAILURES:
-    tests/actual_tests_bless/abort.rs (revision run)
+    tests/actual_tests_bless/abort.rs
     tests/actual_tests_bless/aux_build_not_found.rs
     tests/actual_tests_bless/aux_proc_macro_misuse.rs
     tests/actual_tests_bless/aux_proc_macro_no_main.rs
     tests/actual_tests_bless/compile_flags_quotes.rs
     tests/actual_tests_bless/compiletest-rs-command.rs
-    tests/actual_tests_bless/failing_executable.rs (revision run)
+    tests/actual_tests_bless/failing_executable.rs
     tests/actual_tests_bless/no_main.rs
     tests/actual_tests_bless/no_main_manual.rs
     tests/actual_tests_bless/no_test.rs
     tests/actual_tests_bless/non_top_level_configs.rs
     tests/actual_tests_bless/pass_with_annotation.rs
     tests/actual_tests_bless/revised_revision.rs
-    tests/actual_tests_bless/revisioned_executable.rs (revision panic.run)
-    tests/actual_tests_bless/revisioned_executable_panic.rs (revision run.run)
+    tests/actual_tests_bless/revisioned_executable.rs (revision panic)
+    tests/actual_tests_bless/revisioned_executable_panic.rs (revision run)
     tests/actual_tests_bless/revisions_bad.rs (revision bar)
-    tests/actual_tests_bless/rustfix-fail-revisions.a.fixed (revision a)
-    tests/actual_tests_bless/rustfix-fail-revisions.b.fixed (revision b)
-    tests/actual_tests_bless/rustfix-fail.fixed
+    tests/actual_tests_bless/rustfix-fail-revisions.rs (revision a)
+    tests/actual_tests_bless/rustfix-fail-revisions.rs (revision b)
+    tests/actual_tests_bless/rustfix-fail.rs
     tests/actual_tests_bless/unknown_revision.rs
     tests/actual_tests_bless/unknown_revision2.rs
     tests/actual_tests_bless/wrong_diagnostic_code.rs
 
-test result: FAIL. 22 failed; 24 passed; 3 ignored;
+test result: FAIL. 22 failed; 14 passed; 3 ignored;
 
 Building dependencies ... ok
 tests/actual_tests_bless_yolo/revisions_bad.rs (revision `foo`) ... ok
 tests/actual_tests_bless_yolo/revisions_bad.rs (revision `bar`) ... ok
-tests/actual_tests_bless_yolo/rustfix-maybe-incorrect.fixed ... ok
 tests/actual_tests_bless_yolo/rustfix-maybe-incorrect.rs ... ok
-tests/actual_tests_bless_yolo/rustfix-multiple-fail.1.fixed ... ok
-tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed ... FAILED
-tests/actual_tests_bless_yolo/rustfix-multiple-fail.3.fixed ... ok
-tests/actual_tests_bless_yolo/rustfix-multiple-fail.rs ... ok
+tests/actual_tests_bless_yolo/rustfix-multiple-fail.rs ... FAILED
 
-FAILED TEST: tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed
+FAILED TEST: tests/actual_tests_bless_yolo/rustfix-multiple-fail.rs
 command: "rustc" "--error-format=json" "--out-dir" "$TMP "tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--edition" "2021" "--crate-name" "rustfix_multiple_fail"
 
 error: test got exit status: 1, but expected 0
- --> tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed:1:8
+ --> tests/actual_tests_bless_yolo/rustfix-multiple-fail.rs:1:8
   |
-1 | pub fn f(_: &i32) -> &i32 {
+1 | pub fn f(_: i32) -> &i32 {
   |        ^ after rustfix is applied, all errors should be gone, but weren't
   |
 
@@ -1093,9 +1078,9 @@ full stdout:
 
 
 FAILURES:
-    tests/actual_tests_bless_yolo/rustfix-multiple-fail.2.fixed
+    tests/actual_tests_bless_yolo/rustfix-multiple-fail.rs
 
-test result: FAIL. 1 failed; 7 passed;
+test result: FAIL. 1 failed; 3 passed;
 
 tests/actual_tests/bad_pattern.rs ... FAILED
 tests/actual_tests/executable.rs ... FAILED

--- a/tests/integrations/basic/Cargo.stdout
+++ b/tests/integrations/basic/Cargo.stdout
@@ -10,39 +10,27 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 
 Building dependencies ... ok
 Building aux file tests/actual_tests/auxiliary/derive_proc_macro.rs ... ok
-tests/actual_tests/aux_derive.fixed ... ok
 tests/actual_tests/aux_derive.rs ... ok
 Building aux file tests/actual_tests/auxiliary/the_proc_macro.rs ... ok
 tests/actual_tests/aux_proc_macro.rs ... ok
-tests/actual_tests/dep_derive.rs (revision `run`) ... ok
 tests/actual_tests/dep_derive.rs ... ok
 tests/actual_tests/error_above.rs ... ok
-tests/actual_tests/executable.rs (revision `run`) ... ok
 tests/actual_tests/executable.rs ... ok
-tests/actual_tests/foomp-rustfix.fixed ... ok
 tests/actual_tests/foomp-rustfix.rs ... ok
 tests/actual_tests/foomp.rs ... ok
-tests/actual_tests/joined_above.fixed ... ok
 tests/actual_tests/joined_above.rs ... ok
-tests/actual_tests/joined_below.fixed ... ok
 tests/actual_tests/joined_below.rs ... ok
-tests/actual_tests/joined_mixed.fixed ... ok
 tests/actual_tests/joined_mixed.rs ... ok
-tests/actual_tests/mac_span.fixed ... ok
 tests/actual_tests/mac_span.rs ... ok
-tests/actual_tests/match_diagnostic_code.fixed ... ok
 tests/actual_tests/match_diagnostic_code.rs ... ok
 tests/actual_tests/no_rustfix.rs ... ok
-tests/actual_tests/rustfix-multiple.1.fixed ... ok
-tests/actual_tests/rustfix-multiple.2.fixed ... ok
 tests/actual_tests/rustfix-multiple.rs ... ok
-tests/actual_tests/stdin.rs (revision `run`) ... ok
 tests/actual_tests/stdin.rs ... ok
 tests/actual_tests/unicode.rs ... ok
 tests/actual_tests/windows_paths.rs ... ok
 tests/actual_tests/subdir/aux_proc_macro.rs ... ok
 
-test result: ok. 30 passed;
+test result: ok. 18 passed;
 
 
 running 0 tests


### PR DESCRIPTION
Two main reasons:

- Having log lines/spinners for each `.fixed` file feels like overkill
- The spinners all resolve at the same time as the main test making them redundant (fixable)