### PR TITLE
Fix `#[proc_macros::...]` being detected as a proc macro crate

### DIFF
--- a/tests/integrations/basic/Cargo.stdout
+++ b/tests/integrations/basic/Cargo.stdout
@@ -9,6 +9,8 @@ running 3 tests
 test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished 
 
 Building dependencies ... ok
+Building aux file tests/actual_tests/auxiliary/proc_macro_attr.rs ... ok
+tests/actual_tests/aux_attr_proc_macro.rs ... ok
 Building aux file tests/actual_tests/auxiliary/derive_proc_macro.rs ... ok
 tests/actual_tests/aux_derive.fixed ... ok
 tests/actual_tests/aux_derive.rs ... ok
@@ -42,7 +44,7 @@ tests/actual_tests/unicode.rs ... ok
 tests/actual_tests/windows_paths.rs ... ok
 tests/actual_tests/subdir/aux_proc_macro.rs ... ok
 
-test result: ok. 30 passed;
+test result: ok. 31 passed;
 
 
 running 0 tests

--- a/tests/integrations/basic/tests/actual_tests/aux_attr_proc_macro.rs
+++ b/tests/integrations/basic/tests/actual_tests/aux_attr_proc_macro.rs
@@ -1,0 +1,9 @@
+//@aux-build:proc_macro_attr.rs
+//@check-pass
+
+extern crate proc_macro_attr;
+
+#[proc_macro_attr::passthrough]
+pub fn f() {}
+
+pub fn g() {}

--- a/tests/integrations/basic/tests/actual_tests/auxiliary/proc_macro_attr.rs
+++ b/tests/integrations/basic/tests/actual_tests/auxiliary/proc_macro_attr.rs
@@ -1,0 +1,8 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn passthrough(_: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}


### PR DESCRIPTION
Our proc macro crate is called `proc_macros` so a few of our tests get compiled with `--crate=proc-macro`, didn't matter for many of them but it does for https://github.com/rust-lang/rust-clippy/blob/3b64ca95a931b0cca63e21de55b24a5bcfd4fb84/tests/ui/implicit_hasher.stderr