### PR TITLE
Add full readme to crate documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,7 @@
     rustc::internal
 )]
 #![deny(missing_docs)]
-
-//! A crate to run the Rust compiler (or other binaries) and test their command line output.
+#![doc = include_str!("../README.md")]
 
 use build_manager::BuildManager;
 pub use color_eyre;


### PR DESCRIPTION
Currently we need to go to the repository to have access to all the syntax information. Instead, this PR includes it directly into the crate documentation (but only when rustdoc is building).