### PR TITLE
replace lazy_static with std's OnceLock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Made more code public for miri to use
+* Replaced `lazy_static` with std's `OnceLock`
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,6 @@ dependencies = [
  "crossbeam-channel",
  "ctrlc",
  "indicatif",
- "lazy_static",
  "levenshtein",
  "prettydiff",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ doctest = false # but no doc tests
 [dependencies]
 rustc_version = "0.4"
 colored = "2"
-lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 cargo_metadata = "0.18"

--- a/tests/integrations/basic-bin/Cargo.lock
+++ b/tests/integrations/basic-bin/Cargo.lock
@@ -728,7 +728,6 @@ dependencies = [
  "comma",
  "crossbeam-channel",
  "indicatif",
- "lazy_static",
  "levenshtein",
  "prettydiff",
  "regex",

--- a/tests/integrations/basic-fail-mode/Cargo.lock
+++ b/tests/integrations/basic-fail-mode/Cargo.lock
@@ -728,7 +728,6 @@ dependencies = [
  "comma",
  "crossbeam-channel",
  "indicatif",
- "lazy_static",
  "levenshtein",
  "prettydiff",
  "regex",

--- a/tests/integrations/basic-fail/Cargo.lock
+++ b/tests/integrations/basic-fail/Cargo.lock
@@ -728,7 +728,6 @@ dependencies = [
  "comma",
  "crossbeam-channel",
  "indicatif",
- "lazy_static",
  "levenshtein",
  "prettydiff",
  "regex",

--- a/tests/integrations/basic/Cargo.lock
+++ b/tests/integrations/basic/Cargo.lock
@@ -651,7 +651,6 @@ dependencies = [
  "comma",
  "crossbeam-channel",
  "indicatif",
- "lazy_static",
  "levenshtein",
  "prettydiff",
  "regex",

--- a/tests/integrations/cargo-run/Cargo.lock
+++ b/tests/integrations/cargo-run/Cargo.lock
@@ -728,7 +728,6 @@ dependencies = [
  "comma",
  "crossbeam-channel",
  "indicatif",
- "lazy_static",
  "levenshtein",
  "prettydiff",
  "regex",

--- a/tests/integrations/dep-fail/Cargo.lock
+++ b/tests/integrations/dep-fail/Cargo.lock
@@ -577,7 +577,6 @@ dependencies = [
  "comma",
  "crossbeam-channel",
  "indicatif",
- "lazy_static",
  "levenshtein",
  "prettydiff",
  "regex",

--- a/tests/integrations/ui_test_dep_bug/Cargo.lock
+++ b/tests/integrations/ui_test_dep_bug/Cargo.lock
@@ -582,7 +582,6 @@ dependencies = [
  "comma",
  "crossbeam-channel",
  "indicatif",
- "lazy_static",
  "levenshtein",
  "prettydiff",
  "regex",


### PR DESCRIPTION
[OnceLock](https://doc.rust-lang.org/stable/std/sync/struct.OnceLock.html) stable from 1.70, which is current msrv, so use it instead (`lazy_static` still in tree),
# TODO (check if already done)
* [ ] Add tests
* [x] Add CHANGELOG.md entry
