### PR TITLE
Remove global variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui_test"
-version = "0.27.0"
+version = "0.27.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A test framework for testing rustc diagnostics output"

--- a/tests/integrations/basic-bin/Cargo.lock
+++ b/tests/integrations/basic-bin/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic-fail-mode/Cargo.lock
+++ b/tests/integrations/basic-fail-mode/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic-fail/Cargo.lock
+++ b/tests/integrations/basic-fail/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic/Cargo.lock
+++ b/tests/integrations/basic/Cargo.lock
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/cargo-run/Cargo.lock
+++ b/tests/integrations/cargo-run/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "annotate-snippets",
  "anyhow",


### PR DESCRIPTION
This caused multiple invocations of `run_tests` to have the latter ones just not remove their entries from the command line anymore