### PR TITLE
Export parser types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* exported previously-unnameable parser types
+
 ### Changed
 
 ## [0.27.0] - 2024-10-07

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,6 @@ use crate::{
     per_test_config::{Comments, Condition},
     CommandBuilder, Error, Errors,
 };
-pub use color_eyre;
 use color_eyre::eyre::Result;
 use regex::bytes::Regex;
 use spanned::Spanned;

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -142,7 +142,7 @@ fn has_both_insertions_and_deletions(diff: &[DiffOp<'_, &str>]) -> bool {
     seen_l && seen_r
 }
 
-pub fn print_diff(expected: &[u8], actual: &[u8]) {
+pub(crate) fn print_diff(expected: &[u8], actual: &[u8]) {
     let expected_str = String::from_utf8_lossy(expected);
     let actual_str = String::from_utf8_lossy(actual);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,15 @@
     clippy::enum_variant_names,
     clippy::useless_format,
     clippy::too_many_arguments,
-    rustc::internal
+    rustc::internal,
+    // `unnameable_types` was stabilized in 1.79 which is higher than the current MSRV.
+    // Ignore the "unknown lint" warning which is emitted on older versions.
+    unknown_lints
 )]
+#![warn(unreachable_pub, unnameable_types)]
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
 
-use crate::parser::Comments;
 use build_manager::BuildManager;
 use build_manager::NewJob;
 pub use color_eyre;
@@ -64,6 +67,7 @@ mod tests;
 pub use cmd::*;
 pub use config::*;
 pub use error::*;
+pub use parser::*;
 pub use spanned;
 
 /// Run all tests as described in the config argument.
@@ -146,8 +150,6 @@ pub fn default_per_file_config(config: &mut Config, file_contents: &Spanned<Vec<
 /// Ignores various settings from `Config` that relate to finding test files.
 #[cfg(feature = "rustc")]
 pub fn test_command(mut config: Config, path: &Path) -> Result<Command> {
-    use status_emitter::SilentStatus;
-
     config.fill_host_and_target()?;
 
     let content = Spanned::read_from_file(path)

--- a/src/parser/spanned.rs
+++ b/src/parser/spanned.rs
@@ -1,5 +1,6 @@
-pub use spanned::*;
+pub(crate) use spanned::*;
 
+/// An optional spanned value.
 #[derive(Debug, Clone)]
 pub struct OptWithLine<T>(Option<Spanned<T>>);
 
@@ -30,6 +31,7 @@ impl<T> Default for OptWithLine<T> {
 }
 
 impl<T> OptWithLine<T> {
+    /// Creates a new optional spanned value.
     pub fn new(data: T, span: Span) -> Self {
         Self(Some(Spanned::new(data, span)))
     }
@@ -47,6 +49,7 @@ impl<T> OptWithLine<T> {
         }
     }
 
+    /// Consumes `self` and returns the inner value.
     #[must_use]
     pub fn into_inner(self) -> Option<Spanned<T>> {
         self.0

--- a/src/status_emitter/text.rs
+++ b/src/status_emitter/text.rs
@@ -431,7 +431,7 @@ impl TestStatus for TextTest {
                 stderr: &'a [u8],
                 stdout: &'a [u8],
             }
-            impl<'a> Drop for Guard<'a> {
+            impl Drop for Guard<'_> {
                 fn drop(&mut self) {
                     println!("{}", "full stderr:".bold());
                     std::io::stdout().write_all(self.stderr).unwrap();


### PR DESCRIPTION
`CommentParser` is unnameable from outside this crate, meaning a user cannot declare a parser function with `fn`, only inline with a closure. I've fixed this by exporting `parser::*`, and enabled the `unreachable_pub` and `unnameable_types` to catch this and other unreachable types.