### PR TITLE
Export default diagnostics extractors

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,10 +1,17 @@
 //! Data structures for handling diagnostic output from tests.
 
-#[cfg(feature = "rustc")]
-use cargo_metadata::diagnostic::DiagnosticLevel;
+use std::path::Path;
 
-#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
+#[cfg(feature = "rustc")]
+pub mod rustc;
+
+/// Default diagnostics extractor that does nothing.
+pub fn default_diagnostics_extractor(_path: &Path, _stderr: &[u8]) -> Diagnostics {
+    Diagnostics::default()
+}
+
 /// The different levels of diagnostic messages and their relative ranking.
+#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub enum Level {
     /// internal compiler errors
     Ice = 5,
@@ -18,21 +25,6 @@ pub enum Level {
     Note = 1,
     /// Only used for "For more information about this error, try `rustc --explain EXXXX`".
     FailureNote = 0,
-}
-
-#[cfg(feature = "rustc")]
-impl From<DiagnosticLevel> for Level {
-    fn from(value: DiagnosticLevel) -> Self {
-        match value {
-            DiagnosticLevel::Ice => Level::Ice,
-            DiagnosticLevel::Error => Level::Error,
-            DiagnosticLevel::Warning => Level::Warn,
-            DiagnosticLevel::FailureNote => Level::FailureNote,
-            DiagnosticLevel::Note => Level::Note,
-            DiagnosticLevel::Help => Level::Help,
-            other => panic!("rustc got a new kind of diagnostic level: {other:?}"),
-        }
-    }
 }
 
 impl std::str::FromStr for Level {
@@ -50,8 +42,8 @@ impl std::str::FromStr for Level {
     }
 }
 
-#[derive(Debug)]
 /// A diagnostic message.
+#[derive(Debug)]
 pub struct Message {
     /// The diagnostic level at which this message was emitted
     pub level: Level,
@@ -65,8 +57,8 @@ pub struct Message {
     pub code: Option<String>,
 }
 
-#[derive(Debug)]
-/// All the diagnostics that were emitted in a test
+/// All the diagnostics that were emitted in a test.
+#[derive(Default, Debug)]
 pub struct Diagnostics {
     /// Rendered and concatenated version of all diagnostics.
     /// This is equivalent to non-json diagnostics.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,6 @@ mod mode;
 pub mod nextest;
 mod parser;
 pub mod per_test_config;
-#[cfg(feature = "rustc")]
-mod rustc_stderr;
 pub mod status_emitter;
 pub mod test_result;
 
@@ -104,6 +102,7 @@ pub fn run_tests(mut config: Config) -> Result<()> {
 
 /// The filter used by `run_tests` to only run on `.rs` files that are
 /// specified by [`Config::filter_files`] and [`Config::skip_files`].
+///
 /// Returns `None` if there is no extension or the extension is not `.rs`.
 pub fn default_file_filter(path: &Path, config: &Config) -> Option<bool> {
     path.extension().filter(|&ext| ext == "rs")?;

--- a/src/per_test_config.rs
+++ b/src/per_test_config.rs
@@ -1,5 +1,6 @@
-//! This module allows you to configure the default settings for all
-//! tests. All data structures here are normally parsed from `@` comments
+//! This module allows you to configure the default settings for all tests.
+//!
+//! All data structures here are normally parsed from `@` comments
 //! in the files. These comments still overwrite the defaults, although
 //! some boolean settings have no way to disable them.
 


### PR DESCRIPTION
The config `diagnostic_extractor`s provided by the `rustc` feature are not exported but reachable through `Config::{cargo,rustc}().diagnostic_extractor`; making these public would let users import the function directly instead of having it to access it through `Config` methods.
I've renamed them and moved them to the `diagnostics` module, as well as added the default one as a separate function.

My use case for this is I am testing another compiler that can emit JSON diagnostics using the rustc format, but everything else about the configuration will be different, so it doesn't really make sense to call `Config::rustc` if it wasn't for this method.

BTW I was able to migrate to this library from a compiletest-rs fork pretty easily, thanks a lot for developing this!