### PR TITLE
Move revision-specific args to a custom flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* moved rustc revision-specific arguments (`--cfg=<revision>`...) to a custom flag (`custom_flags::revision_args`)
+
 ## [0.27.0] - 2024-10-07
 
 ### Added

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "rustc")]
 use crate::{
-    aux_builds::AuxBuilder, custom_flags::edition::Edition, custom_flags::run::Run,
+    aux_builds::AuxBuilder, custom_flags::edition::Edition,
+    custom_flags::revision_args::RustcRevisionArgs, custom_flags::run::Run,
     custom_flags::rustfix::RustfixMode, custom_flags::Flag, filter::Match,
 };
 use crate::{
@@ -129,6 +130,9 @@ impl Config {
             }
         }
 
+        comment_defaults
+            .base()
+            .add_custom("rustc-revision-args", RustcRevisionArgs);
         comment_defaults
             .base()
             .add_custom("edition", Edition("2021".into()));

--- a/src/custom_flags.rs
+++ b/src/custom_flags.rs
@@ -11,6 +11,8 @@ use std::{
 #[cfg(feature = "rustc")]
 pub mod edition;
 #[cfg(feature = "rustc")]
+pub mod revision_args;
+#[cfg(feature = "rustc")]
 pub mod run;
 pub mod rustfix;
 

--- a/src/custom_flags/revision_args.rs
+++ b/src/custom_flags/revision_args.rs
@@ -1,0 +1,32 @@
+//! Custom flag for setting rustc revision-specific args.
+
+use super::Flag;
+use crate::{build_manager::BuildManager, per_test_config::TestConfig, Errored};
+
+/// Set rustc revision-specific args.
+#[derive(Clone, Debug)]
+pub struct RustcRevisionArgs;
+
+impl Flag for RustcRevisionArgs {
+    fn clone_inner(&self) -> Box<dyn Flag> {
+        Box::new(self.clone())
+    }
+
+    fn must_be_unique(&self) -> bool {
+        true
+    }
+
+    fn apply(
+        &self,
+        cmd: &mut std::process::Command,
+        config: &TestConfig,
+        _build_manager: &BuildManager,
+    ) -> Result<(), Errored> {
+        let revision = config.status.revision();
+        if !revision.is_empty() {
+            cmd.arg(format!("--cfg={revision}"));
+            cmd.arg(format!("-Cextra-filename={revision}"));
+        }
+        Ok(())
+    }
+}

--- a/src/per_test_config.rs
+++ b/src/per_test_config.rs
@@ -133,10 +133,6 @@ impl TestConfig {
     pub fn build_command(&self, build_manager: &BuildManager) -> Result<Command, Errored> {
         let mut cmd = self.config.program.build(&self.config.out_dir);
         cmd.arg(self.status.path());
-        if !self.status.revision().is_empty() {
-            cmd.arg(format!("--cfg={}", self.status.revision()));
-            cmd.arg(format!("-Cextra-filename={}", self.status.revision()));
-        }
         for r in self.comments() {
             cmd.args(&r.compile_flags);
         }

--- a/tests/integrations/basic-fail/Cargo.stdout
+++ b/tests/integrations/basic-fail/Cargo.stdout
@@ -826,7 +826,7 @@ full stdout:
 
 
 FAILED TEST: tests/actual_tests_bless/revisions_bad.rs (revision `bar`)
-command: "rustc" "--error-format=json" "--out-dir" "$TMP "tests/actual_tests_bless/revisions_bad.rs" "--cfg=bar" "-Cextra-filename=bar" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--edition" "2021"
+command: "rustc" "--error-format=json" "--out-dir" "$TMP "tests/actual_tests_bless/revisions_bad.rs" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib" "--extern" "basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "-L" "$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug" "--edition" "2021" "--cfg=bar" "-Cextra-filename=bar"
 
 error: ``main` function not found in crate `revisions_bad`` not found in diagnostics outside the testfile
  --> tests/actual_tests_bless/revisions_bad.rs:4:31


### PR DESCRIPTION
Closes https://github.com/oli-obk/ui_test/issues/290 by implementing the second suggestion in https://github.com/oli-obk/ui_test/issues/290#issuecomment-2447877332.

# TODO (check if already done)
* [x] Add tests
* [x] Add CHANGELOG.md entry

Should already be tested by existing revisions tests.