### PR TITLE
Fix missing lines in diff output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* missing lines in diff output 
+
 ### Changed
 
 ### Removed

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -39,8 +39,17 @@ fn row(row: DiffOp<'_, &str>) {
             skip(l);
         }
         Replace(l, r) => {
-            for (l, r) in l.iter().zip(r) {
-                print_line_diff(l, r);
+            if l.len() == r.len() {
+                for (l, r) in l.iter().zip(r) {
+                    print_line_diff(l, r);
+                }
+            } else {
+                for l in l {
+                    println!("{}{}", "-".red(), l.red());
+                }
+                for r in r {
+                    println!("{}{}", "+".green(), r.green());
+                }
             }
         }
         Insert(r) => {

--- a/tests/integrations/basic-fail/Cargo.stdout
+++ b/tests/integrations/basic-fail/Cargo.stdout
@@ -1229,8 +1229,16 @@ Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/ba
 + --> tests/actual_tests/bad_pattern.rs:1:5
    |
 -4 |     add("42", 3);
-+1 | use basic_fail::add;
 -  |     --- ^^^^ expected `usize`, found `&str`
+-  |     |
+-  |     arguments to this function are incorrect
+-  |
+-note: function defined here
+- --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC
+-  |
+-1 | pub fn add(left: usize, right: usize) -> usize {
+-  |        ^^^
++1 | use basic_fail::add;
 +  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
  
 -error: aborting due to previous error
@@ -1350,8 +1358,14 @@ Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/fo
 + --> tests/actual_tests/foomp.rs:1:5
    |
 -4 |     add("42", 3);
-+1 | use basic_fail::add;
 -  |     --- ^^^^ expected `usize`, found `&str`
+-  |
+-note: function defined here
+- --> $DIR/tests/integrations/basic/src/lib.rs:LL:CC
+-  |
+-1 | pub fn add(left: usize, right: usize) -> usize {
+-  |        ^^^ some expected text that isn't in the actual message
++1 | use basic_fail::add;
 +  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
  
 -error: aborting doo to previous error
@@ -1400,8 +1414,16 @@ Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/fo
 + --> tests/actual_tests/foomp2.rs:1:5
    |
 -4 |     add("42", 3);
-+1 | use basic_fail::add;
 -  |     --- ^^^^ expected `usize`, found `&str`
+-  |     |
+-  |     arguments to this function are incorrect
+-  |
+-note: function defined here
+- --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC
+-  |
+-1 | pub fn add(left: usize, right: usize) -> usize {
+-  |        ^^^
++1 | use basic_fail::add;
 +  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
  
 -error: aborting due to previous error
@@ -1515,8 +1537,16 @@ Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/ru
 + --> tests/actual_tests/rustc_ice.rs:5:5
    |
 -8 |     add("42", 3);
-+5 | use basic_fail::add;
 -  |     --- ^^^^ expected `usize`, found `&str`
+-  |     |
+-  |     arguments to this function are incorrect
+-  |
+-note: function defined here
+- --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC
+-  |
+-1 | pub fn add(left: usize, right: usize) -> usize {
+-  |        ^^^
++5 | use basic_fail::add;
 +  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
  
  thread 'rustc' panicked


### PR DESCRIPTION
Fixes https://github.com/oli-obk/ui_test/issues/144

`Replaced` can contain a different number of lines in `l` and `r`, so fall back to a plain diff output in that case