### PR TITLE
Correcting incorrect example

### DIFF
--- a/examples_tests/rustc_basic/aux_derive.stderr
+++ b/examples_tests/rustc_basic/aux_derive.stderr
@@ -20,14 +20,12 @@ error[E0384]: cannot assign twice to immutable variable `x`
  --> examples_tests/rustc_basic/aux_derive.rs:8:5
   |
 7 |     let x = Foo;
-  |         - first assignment to `x`
+  |         -
+  |         |
+  |         first assignment to `x`
+  |         help: consider making this binding mutable: `mut x`
 8 |     x = Foo;
   |     ^^^^^^^ cannot assign twice to immutable variable
-  |
-help: consider making this binding mutable
-  |
-7 |     let mut x = Foo;
-  |         +++
 
 error: aborting due to 1 previous error; 2 warnings emitted
 


### PR DESCRIPTION
Right now the examples fail; this fixes the examples.

# TODO (check if already done)
* [x] Add tests
* [x] Add CHANGELOG.md entry
