### PR TITLE
prefer CARGO_TARGET_TMPDIR as location for temporary build files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -177,8 +177,9 @@ impl Config {
             program: CommandBuilder::rustc(),
             output_conflict_handling: error_on_output_conflict,
             bless_command: None,
-            out_dir: std::env::var_os("CARGO_TARGET_DIR")
+            out_dir: option_env!("CARGO_TARGET_TMPDIR")
                 .map(PathBuf::from)
+                .or_else(|| std::env::var_os("CARGO_TARGET_DIR").map(PathBuf::from))
                 .unwrap_or_else(|| std::env::current_dir().unwrap().join("target"))
                 .join("ui"),
             skip_files: Vec::new(),


### PR DESCRIPTION
Based on discussion at https://github.com/rust-lang/cargo/issues/14125#issuecomment-2857356496.

I wasn't sure whether to use build-time or run-time env var lookup. The docs only mention `CARGO_TARGET_TMPDIR` being set at buildtime for tests. Does ui_test support being built outside of tests? The docs don't mention `CARGO_TARGET_DIR` being set at all so no idea who sets that or when, I figured I'd just keep it as a fallback.