### PR TITLE
JSON emitter: escape backslashes on Windows

### DIFF
--- a/src/status_emitter/json.rs
+++ b/src/status_emitter/json.rs
@@ -13,45 +13,59 @@ use bstr::ByteSlice;
 
 // MAINTENANCE REGION START
 
-// When integrating with a new libtest version, update all emit_xxx functions.
+// When integrating with a new libtest version, update all xxx_event functions.
 
-fn emit_suite_end(failed: usize, filtered_out: usize, ignored: usize, passed: usize, status: &str) {
+fn suite_end_event(
+    failed: usize,
+    filtered_out: usize,
+    ignored: usize,
+    passed: usize,
+    status: &str,
+) -> String {
     // Adapted from test::formatters::json::write_run_finish().
-    println!(
+    format!(
         r#"{{ "type": "suite", "event": "{status}", "passed": {passed}, "failed": {failed}, "ignored": {ignored}, "measured": 0, "filtered_out": {filtered_out} }}"#
-    );
+    )
 }
 
-fn emit_suite_start() {
+fn suite_start_event() -> String {
     // Adapted from test::formatters::json::write_run_start().
-    println!(r#"{{ "type": "suite", "event": "started" }}"#);
+    String::from(r#"{ "type": "suite", "event": "started" }"#)
 }
 
-fn emit_test_end(name: &String, revision: &String, path: &Path, status: &str, diags: &str) {
-    let displayed_path = path.display();
-    let stdout = if diags.is_empty() {
+fn test_end_event(name: &str, revision: &str, path: &Path, status: &str, diags: &str) -> String {
+    let escaped_name = escape_backslashes(name);
+    let escaped_revision = escape_backslashes(revision);
+    let escaped_path = escape_backslashes(&path.display().to_string());
+    let escaped_stdout = if diags.is_empty() {
         String::new()
     } else {
-        let triaged_diags = serde_json::to_string(diags).unwrap();
-        format!(r#", "stdout": {triaged_diags}"#)
+        let escaped_diags = serde_json::to_string(&escape_backslashes(diags)).unwrap();
+        format!(r#", "stdout": {}"#, escaped_diags)
     };
 
     // Adapted from test::formatters::json::write_event().
-    println!(
-        r#"{{ "type": "test", "event": "{status}", "name": "{name} ({revision}) - {displayed_path}"{stdout} }}"#
-    );
+    format!(
+        r#"{{ "type": "test", "event": "{status}", "name": "{escaped_name} ({escaped_revision}) - {escaped_path}"{escaped_stdout} }}"#
+    )
 }
 
-fn emit_test_start(name: &String, revision: &String, path: &Path) {
-    let displayed_path = path.display();
+fn test_start_event(name: &str, revision: &str, path: &Path) -> String {
+    let escaped_name = escape_backslashes(name);
+    let escaped_revision = escape_backslashes(revision);
+    let escaped_path = escape_backslashes(&path.display().to_string());
 
     // Adapted from test::formatters::json::write_test_start().
-    println!(
-        r#"{{ "type": "test", "event": "started", "name": "{name} ({revision}) - {displayed_path}" }}"#
-    );
+    format!(
+        r#"{{ "type": "test", "event": "started", "name": "{escaped_name} ({escaped_revision}) - {escaped_path}" }}"#
+    )
 }
 
 // MAINTENANCE REGION END
+
+fn escape_backslashes(s: &str) -> String {
+    s.replace('\\', "\\\\")
+}
 
 /// A JSON output emitter.
 #[derive(Clone)]
@@ -60,7 +74,7 @@ pub struct JSON {}
 impl JSON {
     /// Create a new instance of a JSON output emitter.
     pub fn new() -> Self {
-        emit_suite_start();
+        println!("{}", suite_start_event());
 
         JSON {}
     }
@@ -88,7 +102,10 @@ impl StatusEmitter for JSON {
             "ok"
         };
 
-        emit_suite_end(failed, filtered, ignored, succeeded, status);
+        println!(
+            "{}",
+            suite_end_event(failed, filtered, ignored, succeeded, status)
+        );
 
         Box::new(())
     }
@@ -99,7 +116,7 @@ impl StatusEmitter for JSON {
         let name = path.to_str().unwrap().to_string();
         let revision = String::new();
 
-        emit_test_start(&name, &revision, &path);
+        println!("{}", test_start_event(&name, &revision, &path));
 
         Box::new(JSONStatus {
             name,
@@ -140,7 +157,10 @@ impl TestStatus for JSONStatus {
             String::new()
         };
 
-        emit_test_end(&self.name, &self.revision, self.path(), status, &diags);
+        println!(
+            "{}",
+            test_end_event(&self.name, &self.revision, self.path(), status, &diags)
+        );
     }
 
     /// Invoked before each failed test prints its errors along with a drop guard that can
@@ -185,4 +205,79 @@ impl TestStatus for JSONStatus {
     fn revision(&self) -> &str {
         &self.revision
     }
+}
+
+#[test]
+fn escape_backslashes_escapes() {
+    assert_eq!(escape_backslashes(r#"\aaa\bbb"#), r#"\\aaa\\bbb"#);
+}
+
+#[test]
+fn suite_end_event_constructs_event() {
+    assert_eq!(
+        suite_end_event(
+            12, // failed
+            34, // filtered_out
+            56, // ignored
+            78, // passed
+            "status"
+        ),
+        r#"{ "type": "suite", "event": "status", "passed": 78, "failed": 12, "ignored": 56, "measured": 0, "filtered_out": 34 }"#
+    );
+}
+
+#[test]
+fn suite_start_event_constructs_event() {
+    assert_eq!(
+        suite_start_event(),
+        r#"{ "type": "suite", "event": "started" }"#
+    );
+}
+
+#[test]
+fn test_end_event_constructs_event() {
+    assert_eq!(
+        test_end_event("name", "revision", Path::new("aaa/bbb"), "status", "diags"),
+        r#"{ "type": "test", "event": "status", "name": "name (revision) - aaa/bbb", "stdout": "diags" }"#
+    );
+}
+
+#[test]
+fn test_end_event_constructs_event_with_escapes() {
+    assert_eq!(
+        test_end_event(r#"aaa\bbb"#, r#"ccc ddd\eee"#, Path::new(r#"fff\ggg"#), "status", r#""rustc" "--error-format=json""#),
+        r#"{ "type": "test", "event": "status", "name": "aaa\\bbb (ccc ddd\\eee) - fff\\ggg", "stdout": "\"rustc\" \"--error-format=json\"" }"#
+    );
+}
+
+#[test]
+fn test_end_event_constructs_event_without_revision() {
+    assert_eq!(
+        test_end_event("name", "", Path::new("aaa/bbb"), "status", "diags"),
+        r#"{ "type": "test", "event": "status", "name": "name () - aaa/bbb", "stdout": "diags" }"#
+    );
+}
+
+#[test]
+fn test_end_event_constructs_event_without_stdout() {
+    assert_eq!(
+        test_end_event("name", "revision", Path::new("aaa/bbb"), "status", ""),
+        r#"{ "type": "test", "event": "status", "name": "name (revision) - aaa/bbb" }"#
+    );
+}
+
+#[test]
+fn test_start_event_constructs_event() {
+    assert_eq!(
+        test_start_event("name", "revision", Path::new("aaa/bbb")),
+        r#"{ "type": "test", "event": "started", "name": "name (revision) - aaa/bbb" }"#
+    );
+}
+
+#[test]
+fn test_start_event_constructs_event_with_escapes() {
+    assert_eq!(
+        test_start_event(r#"aaa\bbb"#, r#"ccc ddd\eee"#, Path::new(r#"fff\ggg"#)),
+        r#"{ "type": "test", "event": "started", "name": "aaa\\bbb (ccc ddd\\eee) - fff\\ggg" }"#
+    );
 }


### PR DESCRIPTION
This PR updates the JSON emitter to properly escape backslashes, which usually occurr on Windows, in test paths and revisions.

The PR also changes all `emit_xxx` function into `xxx_event` function which now construct a `String` which represents the related event, and adds unit tests to validate the `xxx_event` functions.

Fixes: https://github.com/oli-obk/ui_test/issues/326


# TODO (check if already done)
* [ ] Add tests
* [ ] Add CHANGELOG.md entry
