### PR TITLE
dependencies: heuristic to distinguish host and target artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- DependencyBuilder: if `config.target` is set (which is always the case if you use `run_tests_generic`),
+  ui_test now supports the same crate showing up as a direct dependency and a dependency of a proc-macro.
+
 ### Removed
 
 ## [0.30.1] - 2025-05-28

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui_test"
-version = "0.30.1"
+version = "0.30.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A test framework for testing rustc diagnostics output"

--- a/tests/integrations/basic-bin/Cargo.lock
+++ b/tests/integrations/basic-bin/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic-fail-mode/Cargo.lock
+++ b/tests/integrations/basic-fail-mode/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic-fail/Cargo.lock
+++ b/tests/integrations/basic-fail/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic/Cargo.lock
+++ b/tests/integrations/basic/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic/Cargo.lock
+++ b/tests/integrations/basic/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
 name = "basic"
 version = "0.1.0"
 dependencies = [
+ "quote",
  "serde_derive",
  "tempfile",
  "ui_test",

--- a/tests/integrations/basic/Cargo.toml
+++ b/tests/integrations/basic/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# A proc-macro dependency, needs special treatment.
 serde_derive = "1.0"
+# `quote` now shows up both as host and target dependency -- let's make sure that works.
+quote = "1.0.25"
 
 [dev-dependencies]
 ui_test = { path = "../../.."}

--- a/tests/integrations/cargo-run/Cargo.lock
+++ b/tests/integrations/cargo-run/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/dep-fail/Cargo.lock
+++ b/tests/integrations/dep-fail/Cargo.lock
@@ -461,7 +461,9 @@ dependencies = [
 
 [[package]]
 name = "spanned"
-version = "0.4.0"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4b0c055fde758f086eb4a6e73410247df8a3837fd606d2caeeaf72aa566d"
 dependencies = [
  "anyhow",
  "bstr",
@@ -564,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/ui_test_dep_bug/Cargo.lock
+++ b/tests/integrations/ui_test_dep_bug/Cargo.lock
@@ -462,7 +462,9 @@ dependencies = [
 
 [[package]]
 name = "spanned"
-version = "0.4.0"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4b0c055fde758f086eb4a6e73410247df8a3837fd606d2caeeaf72aa566d"
 dependencies = [
  "anyhow",
  "bstr",
@@ -569,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "annotate-snippets",
  "anyhow",


### PR DESCRIPTION
Fixes https://github.com/oli-obk/ui_test/issues/327 by looking at the path in which artifacts are stored: if we pass `--target` to cargo, that will be different for host and target crates. If a non-proc-macro host crate shows up, we just ignore it during artifact gathering.

I have confirmed that in the context of https://github.com/rust-lang/rust-clippy/pull/14883 this makes the dependency build work.

# TODO (check if already done)
* [x] Add tests
* [x] Add CHANGELOG.md entry
* [x] Bumped minor version and committed lockfiles in case a release is desired
