### PR TITLE
rust-toolchain: add rust-src component

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.78"
-components = [ "rustfmt", "clippy" ]
+components = [ "rustfmt", "clippy", "rust-src" ]
 profile = "minimal"


### PR DESCRIPTION
rust-src is pretty small, and needed for RA. If we include clippy by default, surely we should also include this.

Also convert the file to Unix line endings. It used Windows line endings for some reason...