### PR TITLE
add missing Cargo.toml to linkedProjects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,13 @@
 {
     "rust-analyzer.linkedProjects": [
+        "./Cargo.toml",
         "./tests/integrations/basic/Cargo.toml",
         "./tests/integrations/basic-bin/Cargo.toml",
         "./tests/integrations/basic-fail/Cargo.toml",
         "./tests/integrations/basic-fail-mode/Cargo.toml",
-        "./tests/integrations/cargo-run/Cargo.toml"
+        "./tests/integrations/cargo-run/Cargo.toml",
+        "./tests/integrations/dep-fail/Cargo.toml",
+        "./tests/integrations/ui_test_dep_bug/Cargo.toml"
     ],
     "nixEnvSelector.nixFile": "${workspaceRoot}/shell.nix"
 }


### PR DESCRIPTION
This does not seem to be included by default, or at least not fully... specifically, if I change the version of the crate in Cargo.toml and then do Ctrl-S, the check build that triggers will update the lockfiles. But `./Cargo.toml` does not get updated unless we add it here.