### PR TITLE
Correct docs to say `Gha::group` is a struct field

### DIFF
--- a/src/status_emitter/gha.rs
+++ b/src/status_emitter/gha.rs
@@ -184,7 +184,7 @@ fn gha_error(error: &Error, test_path: &str, revision: &str) {
 }
 
 /// Emits Github Actions Workspace commands to show the failures directly in the github diff view.
-/// If the const generic `GROUP` boolean is `true`, also emit `::group` commands.
+/// If the [`Self::group`] boolean is `true`, also emit `::group` commands.
 pub struct Gha {
     /// Show a specific name for the final summary.
     pub name: String,


### PR DESCRIPTION
`Gha` no longer has the const generic `GROUP`. This PR updates the docs with this in mind. :)

# TODO (check if already done)
* [ ] ~~Add tests~~
* [ ] ~~Add CHANGELOG.md entry~~ (I don't think this is important enough for a changelog entry)
* [ ] ~~Bumped minor version and committed lockfiles in case a release is desired~~
