### PR TITLE
bump toolchain to 1.86

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A test framework for testing rustc diagnostics output"
 repository = "https://github.com/oli-obk/ui_test"
-rust-version = "1.80"
+rust-version = "1.86"
 
 [lib]
 test = true     # we have unit tests

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ of the error. These comments can take two forms:
     * `LEVEL` can be one of the following (descending order): `ERROR`, `HELP`, `WARN`, `NOTE` or `ICE`
     * If a level is specified explicitly, *all* diagnostics of that level or higher need an annotation. To avoid this see `//@require-annotations-for-level`
     * This checks the output *before* normalization, so you can check things that get normalized away, but need to
-        be careful not to accidentally have a pattern that differs between platforms.
+      be careful not to accidentally have a pattern that differs between platforms.
     * if `XXX` is of the form `/XXX/` it is treated as a regex instead of a substring and will succeed if the regex matches.
 * `//~ CODE` matches by diagnostic code.
     * `CODE` can take multiple forms such as: `E####`, `lint_name`, `tool::lint_name`.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.80"
+channel = "1.86"
 components = [ "rustfmt", "clippy", "rust-src" ]
 profile = "minimal"

--- a/tests/integrations/basic-bin/tests/actual_tests/foomp.stderr
+++ b/tests/integrations/basic-bin/tests/actual_tests/foomp.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `basic_bin`
  --> tests/actual_tests/foomp.rs:3:5
   |
 3 | use basic_bin::add;
-  |     ^^^^^^^^^ use of undeclared crate or module `basic_bin`
+  |     ^^^^^^^^^ use of unresolved module or unlinked crate `basic_bin`
+  |
+  = help: you might be missing a crate named `basic_bin`
 
 error: aborting due to 1 previous error
 

--- a/tests/integrations/basic-fail/Cargo.stdout
+++ b/tests/integrations/basic-fail/Cargo.stdout
@@ -26,18 +26,18 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 { "type": "test", "event": "failed", "name": "tests/actual_tests/bad_pattern_multiple.rs () - tests/actual_tests/bad_pattern_multiple.rs", "stdout": "command: <\"rustc\" \"--error-format=json\" \"--out-dir\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/0/tests/actual_tests\" \"tests/actual_tests/bad_pattern_multiple.rs\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"--edition\" \"2021\"> stdout: <error[E0308]: mismatched types\n --> tests/actual_tests/bad_pattern_multiple.rs:4:9\n  |\n4 |     add(\"42\", 3);\n  |     --- ^^^^ expected `usize`, found `&str`\n  |     |\n  |     arguments to this function are incorrect\n  |\nnote: function defined here\n --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC\n  |\n1 | pub fn add(left: usize, right: usize) -> usize {\n  |        ^^^\n\nerror[E0308]: mismatched types\n --> tests/actual_tests/bad_pattern_multiple.rs:6:9\n  |\n6 |     add(\"42\", 3);\n  |     --- ^^^^ expected `usize`, found `&str`\n  |     |\n  |     arguments to this function are incorrect\n  |\nnote: function defined here\n --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC\n  |\n1 | pub fn add(left: usize, right: usize) -> usize {\n  |        ^^^\n\nerror: aborting due to 2 previous errors\n\nFor more information about this error, try `rustc --explain E0308`.\n> stderr: <>" }
 { "type": "test", "event": "ok", "name": "tests/actual_tests/executable.rs () - tests/actual_tests/executable.rs" }
 { "type": "test", "event": "failed", "name": "tests/actual_tests/executable.rs (run) - tests/actual_tests/executable.rs", "stdout": "command: <\"$DIR/tests/integrations/basic-fail/../../../target/$TMP/0/tests/actual_tests/executable\"> stdout: <> stderr: <42\n>" }
-{ "type": "test", "event": "failed", "name": "tests/actual_tests/executable_compile_err.rs () - tests/actual_tests/executable_compile_err.rs", "stdout": "command: <\"rustc\" \"--error-format=json\" \"--out-dir\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/0/tests/actual_tests\" \"tests/actual_tests/executable_compile_err.rs\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"--edition\" \"2021\"> stdout: <error: this file contains an unclosed delimiter\n --> tests/actual_tests/executable_compile_err.rs:4:2\n  |\n3 | fn main() {\n  |           - unclosed delimiter\n4 |\n  |  ^\n\nerror: aborting due to 1 previous error\n\n> stderr: <>" }
+{ "type": "test", "event": "failed", "name": "tests/actual_tests/executable_compile_err.rs () - tests/actual_tests/executable_compile_err.rs", "stdout": "command: <\"rustc\" \"--error-format=json\" \"--out-dir\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/0/tests/actual_tests\" \"tests/actual_tests/executable_compile_err.rs\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"--edition\" \"2021\"> stdout: <error: this file contains an unclosed delimiter\n --> tests/actual_tests/executable_compile_err.rs:4:2\n  |\n3 | fn main() {\n  |           - unclosed delimiter\n4 |\n  | ^\n\nerror: aborting due to 1 previous error\n\n> stderr: <>" }
 { "type": "test", "event": "failed", "name": "tests/actual_tests/exit_code_fail.rs () - tests/actual_tests/exit_code_fail.rs", "stdout": "command: <\"rustc\" \"--error-format=json\" \"--out-dir\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/0/tests/actual_tests\" \"tests/actual_tests/exit_code_fail.rs\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"--edition\" \"2021\"> stdout: <> stderr: <>" }
 { "type": "test", "event": "failed", "name": "tests/actual_tests/filters.rs () - tests/actual_tests/filters.rs", "stdout": "command: <parse comments> stdout: <> stderr: <>" }
 { "type": "test", "event": "failed", "name": "tests/actual_tests/foomp.rs () - tests/actual_tests/foomp.rs", "stdout": "command: <\"rustc\" \"--error-format=json\" \"--out-dir\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/0/tests/actual_tests\" \"tests/actual_tests/foomp.rs\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"--edition\" \"2021\"> stdout: <error[E0308]: mismatched types\n --> tests/actual_tests/foomp.rs:4:9\n  |\n4 |     add(\"42\", 3);\n  |     --- ^^^^ expected `usize`, found `&str`\n  |     |\n  |     arguments to this function are incorrect\n  |\nnote: function defined here\n --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC\n  |\n1 | pub fn add(left: usize, right: usize) -> usize {\n  |        ^^^\n\nerror: aborting due to 1 previous error\n\nFor more information about this error, try `rustc --explain E0308`.\n> stderr: <>" }
 { "type": "test", "event": "failed", "name": "tests/actual_tests/foomp2.rs () - tests/actual_tests/foomp2.rs", "stdout": "command: <\"rustc\" \"--error-format=json\" \"--out-dir\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/0/tests/actual_tests\" \"tests/actual_tests/foomp2.rs\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"--edition\" \"2021\"> stdout: <error[E0308]: mismatched types\n --> tests/actual_tests/foomp2.rs:4:9\n  |\n4 |     add(\"42\", 3);\n  |     --- ^^^^ expected `usize`, found `&str`\n  |     |\n  |     arguments to this function are incorrect\n  |\nnote: function defined here\n --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC\n  |\n1 | pub fn add(left: usize, right: usize) -> usize {\n  |        ^^^\n\nerror: aborting due to 1 previous error\n\nFor more information about this error, try `rustc --explain E0308`.\n> stderr: <>" }
-{ "type": "test", "event": "failed", "name": "tests/actual_tests/ice_annotations.rs () - tests/actual_tests/ice_annotations.rs", "stdout": "command: <\"rustc\" \"--error-format=json\" \"--out-dir\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/0/tests/actual_tests\" \"tests/actual_tests/ice_annotations.rs\" \"-Ztreat-err-as-bug\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"--edition\" \"2021\"> stdout: <error: internal compiler error[E0308]: mismatched types\n --> tests/actual_tests/ice_annotations.rs:8:9\n  |\n8 |     add(\"42\", 3);\n  |     --- ^^^^ expected `usize`, found `&str`\n  |     |\n  |     arguments to this function are incorrect\n  |\nnote: function defined here\n --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC\n  |\n1 | pub fn add(left: usize, right: usize) -> usize {\n  |        ^^^\n\nthread 'rustc' panicked at compiler/rustc_errors/src/lib.rs:\naborting due to `-Z treat-err-as-bug=1`\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n\nerror: the compiler unexpectedly panicked. this is a bug.\n\nnote: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md\n\nnote: please make sure that you have updated to the latest nightly\n\n
+{ "type": "test", "event": "failed", "name": "tests/actual_tests/ice_annotations.rs () - tests/actual_tests/ice_annotations.rs", "stdout": "command: <\"rustc\" \"--error-format=json\" \"--out-dir\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/0/tests/actual_tests\" \"tests/actual_tests/ice_annotations.rs\" \"-Ztreat-err-as-bug\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"--edition\" \"2021\"> stdout: <error: internal compiler error[E0308]: mismatched types\n --> tests/actual_tests/ice_annotations.rs:8:9\n  |\n8 |     add(\"42\", 3);\n  |     --- ^^^^ expected `usize`, found `&str`\n  |     |\n  |     arguments to this function are incorrect\n  |\nnote: function defined here\n --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC\n  |\n1 | pub fn add(left: usize, right: usize) -> usize {\n  |        ^^^\n\n\nthread 'rustc' panicked at compiler/rustc_errors/src/lib.rs:\naborting due to `-Z treat-err-as-bug=1`\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n\nerror: the compiler unexpectedly panicked. this is a bug.\n\nnote: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md\n\nnote: please make sure that you have updated to the latest nightly\n\n
 { "type": "test", "event": "failed", "name": "tests/actual_tests/inline_chain.rs () - tests/actual_tests/inline_chain.rs", "stdout": "command: <parse comments> stdout: <> stderr: <>" }
 { "type": "test", "event": "failed", "name": "tests/actual_tests/joined_wrong_order.rs () - tests/actual_tests/joined_wrong_order.rs", "stdout": "command: <parse comments> stdout: <> stderr: <>" }
 { "type": "test", "event": "failed", "name": "tests/actual_tests/lone_joined_pattern.rs () - tests/actual_tests/lone_joined_pattern.rs", "stdout": "command: <parse comments> stdout: <> stderr: <>" }
 { "type": "test", "event": "failed", "name": "tests/actual_tests/pattern_too_many_arrow.rs () - tests/actual_tests/pattern_too_many_arrow.rs", "stdout": "command: <parse comments> stdout: <> stderr: <>" }
 { "type": "test", "event": "failed", "name": "tests/actual_tests/pattern_too_many_arrow_above.rs () - tests/actual_tests/pattern_too_many_arrow_above.rs", "stdout": "command: <parse comments> stdout: <> stderr: <>" }
-{ "type": "test", "event": "failed", "name": "tests/actual_tests/rustc_ice.rs () - tests/actual_tests/rustc_ice.rs", "stdout": "command: <\"rustc\" \"--error-format=json\" \"--out-dir\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/0/tests/actual_tests\" \"tests/actual_tests/rustc_ice.rs\" \"-Ztreat-err-as-bug\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"--edition\" \"2021\"> stdout: <error: internal compiler error[E0308]: mismatched types\n --> tests/actual_tests/rustc_ice.rs:8:9\n  |\n8 |     add(\"42\", 3);\n  |     --- ^^^^ expected `usize`, found `&str`\n  |     |\n  |     arguments to this function are incorrect\n  |\nnote: function defined here\n --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC\n  |\n1 | pub fn add(left: usize, right: usize) -> usize {\n  |        ^^^\n\nthread 'rustc' panicked at compiler/rustc_errors/src/lib.rs:\naborting due to `-Z treat-err-as-bug=1`\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n\nerror: the compiler unexpectedly panicked. this is a bug.\n\nnote: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md\n\nnote: please make sure that you have updated to the latest nightly\n\n
+{ "type": "test", "event": "failed", "name": "tests/actual_tests/rustc_ice.rs () - tests/actual_tests/rustc_ice.rs", "stdout": "command: <\"rustc\" \"--error-format=json\" \"--out-dir\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/0/tests/actual_tests\" \"tests/actual_tests/rustc_ice.rs\" \"-Ztreat-err-as-bug\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail.rlib\" \"--extern\" \"basic_fail=$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug/libbasic_fail-$HASH.rmeta\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"-L\" \"$DIR/tests/integrations/basic-fail/../../../target/$TMP/$TRIPLE/debug\" \"--edition\" \"2021\"> stdout: <error: internal compiler error[E0308]: mismatched types\n --> tests/actual_tests/rustc_ice.rs:8:9\n  |\n8 |     add(\"42\", 3);\n  |     --- ^^^^ expected `usize`, found `&str`\n  |     |\n  |     arguments to this function are incorrect\n  |\nnote: function defined here\n --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC\n  |\n1 | pub fn add(left: usize, right: usize) -> usize {\n  |        ^^^\n\n\nthread 'rustc' panicked at compiler/rustc_errors/src/lib.rs:\naborting due to `-Z treat-err-as-bug=1`\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n\nerror: the compiler unexpectedly panicked. this is a bug.\n\nnote: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md\n\nnote: please make sure that you have updated to the latest nightly\n\n
 { "type": "test", "event": "failed", "name": "tests/actual_tests/touching_above_below.rs () - tests/actual_tests/touching_above_below.rs", "stdout": "command: <parse comments> stdout: <> stderr: <>" }
 { "type": "test", "event": "failed", "name": "tests/actual_tests/touching_above_below_chain.rs () - tests/actual_tests/touching_above_below_chain.rs", "stdout": "command: <parse comments> stdout: <> stderr: <>" }
 { "type": "suite", "event": "failed", "passed": 1, "failed": 17, "ignored": 0, "measured": 0, "filtered_out": 0 }
@@ -304,7 +304,7 @@ error: this file contains an unclosed delimiter
 3 | fn main() {
   |           - unclosed delimiter
 4 |
-  |  ^
+  | ^
 
 error: aborting due to 1 previous error
 
@@ -317,7 +317,7 @@ error: this file contains an unclosed delimiter
 3 | fn main() {
   |           - unclosed delimiter
 4 |
-  |  ^
+  | ^
 
 error: aborting due to 1 previous error
 
@@ -510,6 +510,7 @@ note: function defined here
 1 | pub fn add(left: usize, right: usize) -> usize {
   |        ^^^
 
+
 thread 'rustc' panicked at compiler/rustc_errors/src/lib.rs:
 aborting due to `-Z treat-err-as-bug=1`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
@@ -544,6 +545,7 @@ note: function defined here
   |
 1 | pub fn add(left: usize, right: usize) -> usize {
   |        ^^^
+
 
 thread 'rustc' panicked at compiler/rustc_errors/src/lib.rs:
 aborting due to `-Z treat-err-as-bug=1`
@@ -661,6 +663,54 @@ command: "rustc" "--error-format=json" "--out-dir" "$TMP "tests/actual_tests/rus
 error: test got exit status: 101, but expected 1
  = note: the compiler panicked
 
+error: actual output differed from expected
+Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/rustc_ice.stderr` to the actual output
+--- tests/actual_tests/rustc_ice.stderr
++++ <stderr output>
+ error: internal compiler error[E0308]: mismatched types
+  --> tests/actual_tests/rustc_ice.rs:8:9
+... 10 lines skipped ...
+   |        ^^^
+ 
++
+ thread 'rustc' panicked
+
+Full unnormalized output:
+error: internal compiler error[E0308]: mismatched types
+ --> tests/actual_tests/rustc_ice.rs:8:9
+  |
+8 |     add("42", 3);
+  |     --- ^^^^ expected `usize`, found `&str`
+  |     |
+  |     arguments to this function are incorrect
+  |
+note: function defined here
+ --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC
+  |
+1 | pub fn add(left: usize, right: usize) -> usize {
+  |        ^^^
+
+
+thread 'rustc' panicked at compiler/rustc_errors/src/lib.rs:
+aborting due to `-Z treat-err-as-bug=1`
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+error: the compiler unexpectedly panicked. this is a bug.
+
+note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md
+
+note: please make sure that you have updated to the latest nightly
+
+
+
+note: compiler flags: -Z treat-err-as-bug
+
+query stack during panic:
+#0 [typeck] type-checking `main`
+#1 [analysis] running analysis passes on this crate
+end of query stack
+
+
 error: `mismatched types` not found in diagnostics on line 8
  --> tests/actual_tests/rustc_ice.rs:9:17
   |
@@ -689,6 +739,7 @@ note: function defined here
   |
 1 | pub fn add(left: usize, right: usize) -> usize {
   |        ^^^
+
 
 thread 'rustc' panicked at compiler/rustc_errors/src/lib.rs:
 aborting due to `-Z treat-err-as-bug=1`
@@ -964,6 +1015,7 @@ error: test got exit status: 101, but expected 0
   |
 
 full stderr:
+
 thread 'main' panicked at tests/actual_tests_bless/failing_executable.rs:
 assertion `left == right` failed
   left: 5
@@ -1128,6 +1180,7 @@ error: test got exit status: 101, but expected 0
   |
 
 full stderr:
+
 thread 'main' panicked at tests/actual_tests_bless/revisioned_executable_panic.rs:
 explicit panic
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
@@ -1488,14 +1541,15 @@ Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/ba
 -  |     --- ^^^^ expected `usize`, found `&str`
 -  |     |
 -  |     arguments to this function are incorrect
--  |
++1 | use basic_fail::add;
++  |     ^^^^^^^^^^ use of unresolved module or unlinked crate `basic_fail`
+   |
 -note: function defined here
 - --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC
 -  |
 -1 | pub fn add(left: usize, right: usize) -> usize {
 -  |        ^^^
-+1 | use basic_fail::add;
-+  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
++  = help: you might be missing a crate named `basic_fail`
  
 -error: aborting due to previous error
 +error: aborting due to 1 previous error
@@ -1508,7 +1562,9 @@ error[E0432]: unresolved import `basic_fail`
  --> tests/actual_tests/bad_pattern.rs:1:5
   |
 1 | use basic_fail::add;
-  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
+  |     ^^^^^^^^^^ use of unresolved module or unlinked crate `basic_fail`
+  |
+  = help: you might be missing a crate named `basic_fail`
 
 error: aborting due to 1 previous error
 
@@ -1546,14 +1602,15 @@ Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/ba
 -  |     --- ^^^^ expected `usize`, found `&str`
 -  |     |
 -  |     arguments to this function are incorrect
--  |
++1 | use basic_fail::add;
++  |     ^^^^^^^^^^ use of unresolved module or unlinked crate `basic_fail`
+   |
 -note: function defined here
 - --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC
 -  |
 -1 | pub fn add(left: usize, right: usize) -> usize {
 -  |        ^^^
-+1 | use basic_fail::add;
-+  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
++  = help: you might be missing a crate named `basic_fail`
  
 -error[E0308]: mismatched types
 -  --> tests/actual_tests/bad_pattern_multiple.rs:6:9
@@ -1580,7 +1637,9 @@ error[E0432]: unresolved import `basic_fail`
  --> tests/actual_tests/bad_pattern_multiple.rs:1:5
   |
 1 | use basic_fail::add;
-  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
+  |     ^^^^^^^^^^ use of unresolved module or unlinked crate `basic_fail`
+  |
+  = help: you might be missing a crate named `basic_fail`
 
 error: aborting due to 1 previous error
 
@@ -1626,7 +1685,9 @@ error[E0432]: unresolved import `basic_fail`
  --> tests/actual_tests/executable.rs:1:5
   |
 1 | use basic_fail::add;
-  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
+  |     ^^^^^^^^^^ use of unresolved module or unlinked crate `basic_fail`
+  |
+  = help: you might be missing a crate named `basic_fail`
 
 error: aborting due to 1 previous error
 
@@ -1653,7 +1714,7 @@ error: this file contains an unclosed delimiter
 3 | fn main() {
   |           - unclosed delimiter
 4 |
-  |  ^
+  | ^
 
 error: aborting due to 1 previous error
 
@@ -1693,15 +1754,16 @@ Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/fo
 + --> tests/actual_tests/foomp.rs:1:5
    |
 -4 |     add("42", 3);
++1 | use basic_fail::add;
 -  |     --- ^^^^ expected `usize`, found `&str`
--  |
++  |     ^^^^^^^^^^ use of unresolved module or unlinked crate `basic_fail`
+   |
 -note: function defined here
 - --> $DIR/tests/integrations/basic/src/lib.rs:LL:CC
 -  |
 -1 | pub fn add(left: usize, right: usize) -> usize {
 -  |        ^^^ some expected text that isn't in the actual message
-+1 | use basic_fail::add;
-+  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
++  = help: you might be missing a crate named `basic_fail`
  
 -error: aborting doo to previous error
 +error: aborting due to 1 previous error
@@ -1714,7 +1776,9 @@ error[E0432]: unresolved import `basic_fail`
  --> tests/actual_tests/foomp.rs:1:5
   |
 1 | use basic_fail::add;
-  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
+  |     ^^^^^^^^^^ use of unresolved module or unlinked crate `basic_fail`
+  |
+  = help: you might be missing a crate named `basic_fail`
 
 error: aborting due to 1 previous error
 
@@ -1752,14 +1816,15 @@ Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/fo
 -  |     --- ^^^^ expected `usize`, found `&str`
 -  |     |
 -  |     arguments to this function are incorrect
--  |
++1 | use basic_fail::add;
++  |     ^^^^^^^^^^ use of unresolved module or unlinked crate `basic_fail`
+   |
 -note: function defined here
 - --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC
 -  |
 -1 | pub fn add(left: usize, right: usize) -> usize {
 -  |        ^^^
-+1 | use basic_fail::add;
-+  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
++  = help: you might be missing a crate named `basic_fail`
  
 -error: aborting due to previous error
 +error: aborting due to 1 previous error
@@ -1772,7 +1837,9 @@ error[E0432]: unresolved import `basic_fail`
  --> tests/actual_tests/foomp2.rs:1:5
   |
 1 | use basic_fail::add;
-  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
+  |     ^^^^^^^^^^ use of unresolved module or unlinked crate `basic_fail`
+  |
+  = help: you might be missing a crate named `basic_fail`
 
 error: aborting due to 1 previous error
 
@@ -1807,7 +1874,10 @@ error: internal compiler error[E0432]: unresolved import `basic_fail`
  --> tests/actual_tests/ice_annotations.rs:5:5
   |
 5 | use basic_fail::add;
-  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
+  |     ^^^^^^^^^^ use of unresolved module or unlinked crate `basic_fail`
+  |
+  = help: you might be missing a crate named `basic_fail`
+
 
 thread 'rustc' panicked at compiler/rustc_errors/src/lib.rs:
 aborting due to `-Z treat-err-as-bug=1`
@@ -1924,15 +1994,17 @@ Execute `DO NOT BLESS. These are meant to fail` to update `tests/actual_tests/ru
 -  |     --- ^^^^ expected `usize`, found `&str`
 -  |     |
 -  |     arguments to this function are incorrect
--  |
++5 | use basic_fail::add;
++  |     ^^^^^^^^^^ use of unresolved module or unlinked crate `basic_fail`
+   |
 -note: function defined here
 - --> $DIR/tests/integrations/basic-fail/src/lib.rs:LL:CC
 -  |
 -1 | pub fn add(left: usize, right: usize) -> usize {
 -  |        ^^^
-+5 | use basic_fail::add;
-+  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
++  = help: you might be missing a crate named `basic_fail`
  
++
  thread 'rustc' panicked
 
 Full unnormalized output:
@@ -1940,7 +2012,10 @@ error: internal compiler error[E0432]: unresolved import `basic_fail`
  --> tests/actual_tests/rustc_ice.rs:5:5
   |
 5 | use basic_fail::add;
-  |     ^^^^^^^^^^ use of undeclared crate or module `basic_fail`
+  |     ^^^^^^^^^^ use of unresolved module or unlinked crate `basic_fail`
+  |
+  = help: you might be missing a crate named `basic_fail`
+
 
 thread 'rustc' panicked at compiler/rustc_errors/src/lib.rs:
 aborting due to `-Z treat-err-as-bug=1`

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/failing_executable.run.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/failing_executable.run.stderr
@@ -1,3 +1,4 @@
+
 thread 'main' panicked at tests/actual_tests_bless/failing_executable.rs:4:5:
 assertion `left == right` failed
   left: 5

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/revisioned_executable_panic.panic.run.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/revisioned_executable_panic.panic.run.stderr
@@ -1,3 +1,4 @@
+
 thread 'main' panicked at tests/actual_tests_bless/revisioned_executable_panic.rs:6:5:
 explicit panic
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/revisioned_executable_panic.run.run.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/revisioned_executable_panic.run.run.stderr
@@ -1,3 +1,4 @@
+
 thread 'main' panicked at tests/actual_tests_bless/revisioned_executable_panic.rs:6:5:
 explicit panic
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/run_panic.run.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/run_panic.run.stderr
@@ -1,3 +1,4 @@
+
 thread 'main' panicked at tests/actual_tests_bless/run_panic.rs:4:5:
 explicit panic
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/rustfix-fail-revisions.a.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/rustfix-fail-revisions.a.stderr
@@ -2,7 +2,12 @@ error: expected `,` following `match` arm
  --> tests/actual_tests_bless/rustfix-fail-revisions.rs:6:27
   |
 6 |         0 => String::new()
-  |                           ^ help: missing a comma here to end this `match` arm: `,`
+  |                           ^
+  |
+help: missing a comma here to end this `match` arm
+  |
+6 |         0 => String::new(),
+  |                           +
 
 error: aborting due to 1 previous error
 

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/rustfix-fail-revisions.b.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/rustfix-fail-revisions.b.stderr
@@ -2,7 +2,12 @@ error: expected `,` following `match` arm
  --> tests/actual_tests_bless/rustfix-fail-revisions.rs:6:27
   |
 6 |         0 => String::new()
-  |                           ^ help: missing a comma here to end this `match` arm: `,`
+  |                           ^
+  |
+help: missing a comma here to end this `match` arm
+  |
+6 |         0 => String::new(),
+  |                           +
 
 error: aborting due to 1 previous error
 

--- a/tests/integrations/basic-fail/tests/actual_tests_bless/rustfix-fail.stderr
+++ b/tests/integrations/basic-fail/tests/actual_tests_bless/rustfix-fail.stderr
@@ -2,7 +2,12 @@ error: expected `,` following `match` arm
  --> tests/actual_tests_bless/rustfix-fail.rs:5:27
   |
 5 |         0 => String::new()
-  |                           ^ help: missing a comma here to end this `match` arm: `,`
+  |                           ^
+  |
+help: missing a comma here to end this `match` arm
+  |
+5 |         0 => String::new(),
+  |                           +
 
 error: aborting due to 1 previous error
 

--- a/tests/integrations/basic/tests/actual_tests/aux_derive.stderr
+++ b/tests/integrations/basic/tests/actual_tests/aux_derive.stderr
@@ -20,12 +20,14 @@ error[E0384]: cannot assign twice to immutable variable `x`
  --> tests/actual_tests/aux_derive.rs:8:5
   |
 7 |     let x = Foo;
-  |         -
-  |         |
-  |         first assignment to `x`
-  |         help: consider making this binding mutable: `mut x`
+  |         - first assignment to `x`
 8 |     x = Foo;
   |     ^^^^^^^ cannot assign twice to immutable variable
+  |
+help: consider making this binding mutable
+  |
+7 |     let mut x = Foo;
+  |         +++
 
 error: aborting due to 1 previous error; 2 warnings emitted
 

--- a/tests/integrations/basic/tests/actual_tests/match_diagnostic_code.stderr
+++ b/tests/integrations/basic/tests/actual_tests/match_diagnostic_code.stderr
@@ -8,8 +8,9 @@ error[E0308]: mismatched types
   |
 help: change the type of the numeric literal from `u32` to `i32`
   |
-2 |     let _x: i32 = 0i32;
-  |                    ~~~
+2 -     let _x: i32 = 0u32;
+2 +     let _x: i32 = 0i32;
+  |
 
 error: aborting due to 1 previous error
 

--- a/tests/integrations/cargo-run/tests/actual_tests/empty_no_stdin.stderr
+++ b/tests/integrations/cargo-run/tests/actual_tests/empty_no_stdin.stderr
@@ -1,3 +1,4 @@
+
 thread 'main' panicked at src/main.rs:12:5:
 done
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/integrations/cargo-run/tests/actual_tests/matching_stdin.stderr
+++ b/tests/integrations/cargo-run/tests/actual_tests/matching_stdin.stderr
@@ -1,3 +1,4 @@
+
 thread 'main' panicked at src/main.rs:12:5:
 done
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/integrations/cargo-run/tests/actual_tests/mismatching_stdin.stderr
+++ b/tests/integrations/cargo-run/tests/actual_tests/mismatching_stdin.stderr
@@ -1,3 +1,4 @@
+
 thread 'main' panicked at src/main.rs:7:9:
 assertion `left == right` failed
   left: "cake"

--- a/tests/integrations/cargo-run/tests/actual_tests/no_stdin.stderr
+++ b/tests/integrations/cargo-run/tests/actual_tests/no_stdin.stderr
@@ -1,3 +1,4 @@
+
 thread 'main' panicked at src/main.rs:6:26:
 .stdin file is missing line 1
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/integrations/dep-fail/Cargo.stdout
+++ b/tests/integrations/dep-fail/Cargo.stdout
@@ -10,7 +10,7 @@ FAILED TEST: tests/ui/basic_test.rs
 command: "$CMD" "build" "--color=never" "--quiet" "--jobs" "1" "--target-dir" "$DIR/tests/integrations/dep-fail/target/ui/0" "--manifest-path" "tested_crate/Cargo.toml"  "--message-format=json"
 
 full stderr:
-error: could not compile `tested_crate` (lib) due to 2 previous errors
+error: could not compile `tested_crate` (lib) due to 1 previous error
 
 full stdout:
 $DIR/tests/integrations/dep-fail/tested_crate/src/lib.rs
@@ -18,12 +18,9 @@ error: this file contains an unclosed delimiter
  --> src/lib.rs:LL:CC
   |
 1 | pub trait A {
-  |             - ^
+  |             -^
   |             |
   |             unclosed delimiter
-
-$DIR/tests/integrations/dep-fail/tested_crate/src/lib.rs
-error: aborting due to 1 previous error
 
 BuildFinished { success: false }
 


### PR DESCRIPTION
This is needed to even build the latest cargo_metadata. I then ran out of steam for bumping cargo_metadata as its API changed quite a bit, but I figured we could land this preparation step anyway.

I can't quite tell whether the changes in `tests/integrations/basic-fail/Cargo.stdout` are harmless; the rest looks fine to me.