### PR TITLE
text emitter: suggest adding `//@check-pass` when no error patterns present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+- when a test file has no error patterns, there's now a suggestion to add `//@check-pass`
+
 ## [0.30.4] - 2025-11-24
 
 ### Added

--- a/src/status_emitter/text.rs
+++ b/src/status_emitter/text.rs
@@ -683,6 +683,7 @@ fn print_error(error: &Error, path: &Path) {
         }
         Error::NoPatternsFound => {
             print_error_header("expected error patterns, but found none");
+            println!("If this is expected, consider annotating the file with `//@check-pass`");
         }
         Error::PatternFoundInPassTest { mode, span } => {
             let annot = [("expected because of this annotation", span.clone())];

--- a/tests/integrations/basic-fail/Cargo.stdout
+++ b/tests/integrations/basic-fail/Cargo.stdout
@@ -333,6 +333,7 @@ error: test got exit status: 0, but expected 1
  = note: compilation succeeded, but was expected to fail
 
 error: expected error patterns, but found none
+If this is expected, consider annotating the file with `//@check-pass`
 
 full stderr:
 
@@ -930,6 +931,7 @@ error: there was 1 unmatched diagnostic
   |
 
 error: expected error patterns, but found none
+If this is expected, consider annotating the file with `//@check-pass`
 
 full stderr:
 error: expected one of `!` or `::`, found `<eof>`
@@ -1033,6 +1035,7 @@ error: test got exit status: 0, but expected 1
  = note: compilation succeeded, but was expected to fail
 
 error: expected error patterns, but found none
+If this is expected, consider annotating the file with `//@check-pass`
 
 full stderr:
 
@@ -1054,6 +1057,7 @@ error: there was 1 unmatched diagnostic
   |
 
 error: expected error patterns, but found none
+If this is expected, consider annotating the file with `//@check-pass`
 
 full stderr:
 error: cannot mix `bin` crate type with others
@@ -1079,6 +1083,7 @@ error: test got exit status: 0, but expected 1
  = note: compilation succeeded, but was expected to fail
 
 error: expected error patterns, but found none
+If this is expected, consider annotating the file with `//@check-pass`
 
 full stderr:
 
@@ -1321,6 +1326,7 @@ error: test got exit status: 0, but expected 1
  = note: compilation succeeded, but was expected to fail
 
 error: expected error patterns, but found none
+If this is expected, consider annotating the file with `//@check-pass`
 
 full stderr:
 warning: unused variable: `Ě电脑`
@@ -1728,6 +1734,7 @@ error: test got exit status: 0, but expected 1
  = note: compilation succeeded, but was expected to fail
 
 error: expected error patterns, but found none
+If this is expected, consider annotating the file with `//@check-pass`
 
 
 FAILED TEST: tests/actual_tests/filters.rs


### PR DESCRIPTION
The current error message is pretty inactionable -- one needs to dig
into the documentation to even learn about `//@check-pass`. This change
will hopefully reduce the confusion.

# TODO (check if already done)
* [x] Add tests (just updated the existing ones)
* [x] Add CHANGELOG.md entry
* [ ] Bumped minor version and committed lockfiles in case a release is desired
