### PR TITLE
New cargo layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Changed
+
+## [0.30.5] - 2026-05-04
+
+### Added
+
+- Added support for Cargo's new `build-dir` layout
+
+### Fixed
+
 - Update the help string in CLI to include new flags
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui_test"
-version = "0.30.4"
+version = "0.30.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A test framework for testing rustc diagnostics output"

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -185,9 +185,16 @@ fn build_dependencies_inner(
                         filename.pop();
                         // We also validate that the path looks as expected before we actually skip.
                         if filename.file_name().unwrap_or_default() != "deps" {
-                            // Either cargo changed or this is a weird corner case, let's just
-                            // keep it.
-                            break 'skip_crate false;
+                            // Check if the new Cargo build-dir v2 layout is enabled
+                            if filename.file_name().unwrap_or_default() == "out" {
+                                filename.pop(); // `out`
+                                filename.pop(); // `<hash>`
+                                filename.pop(); // `<pkgname>`
+                            } else {
+                                // Either cargo changed or this is a weird corner case, let's just
+                                // keep it.
+                                break 'skip_crate false;
+                            }
                         }
                         filename.pop();
                         // This is the profile name, `debug` or `release` or so.

--- a/tests/integrations/basic-bin/Cargo.lock
+++ b/tests/integrations/basic-bin/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic-fail-mode/Cargo.lock
+++ b/tests/integrations/basic-fail-mode/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic-fail/Cargo.lock
+++ b/tests/integrations/basic-fail/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/basic/Cargo.lock
+++ b/tests/integrations/basic/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/cargo-run/Cargo.lock
+++ b/tests/integrations/cargo-run/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/dep-fail/Cargo.lock
+++ b/tests/integrations/dep-fail/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/tests/integrations/ui_test_dep_bug/Cargo.lock
+++ b/tests/integrations/ui_test_dep_bug/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "annotate-snippets",
  "anyhow",


### PR DESCRIPTION
This PR adds support for Cargo's new `build-dir` layout tracked in https://github.com/rust-lang/cargo/issues/15010.
I opted to not modify the tests as some of them have paths and it felt like it was going to be painful to keep both layouts in tests.
I think we can update the tests when the new `build-dir` lands on stable. wdyt?

Also I'd appreciate if you could cut a new release once this is merged as it blocks https://github.com/rust-lang/rust/pull/155439

# TODO (check if already done)
* [ ] Add tests
* [x] Add CHANGELOG.md entry
* [x] Bumped minor version and committed lockfiles in case a release is desired
* [ ] check if you used AI on this PR

