### PR TITLE
make Errored fields public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Fields of `Errored` are now public, so user-defined flags can report stdout/stderr
+
 ### Fixed
 
 ### Changed

--- a/src/custom_flags.rs
+++ b/src/custom_flags.rs
@@ -31,7 +31,8 @@ pub trait Flag: Send + Sync + UnwindSafe + RefUnwindSafe + std::fmt::Debug {
         Ok(())
     }
 
-    /// Whether this flag causes a test to be filtered out
+    /// Whether this flag causes a test to be filtered out.
+    /// Returning `true` means the test gets ignored.
     fn test_condition(&self, _config: &Config, _comments: &Comments, _revision: &str) -> bool {
         false
     }

--- a/src/test_result.rs
+++ b/src/test_result.rs
@@ -19,13 +19,13 @@ pub type TestResult = Result<TestOk, Errored>;
 /// Information about a test failure.
 pub struct Errored {
     /// Command that failed
-    pub(crate) command: String,
+    pub command: String,
     /// The errors that were encountered.
-    pub(crate) errors: Vec<Error>,
+    pub errors: Vec<Error>,
     /// The full stderr of the test run.
-    pub(crate) stderr: Vec<u8>,
+    pub stderr: Vec<u8>,
     /// The full stdout of the test run.
-    pub(crate) stdout: Vec<u8>,
+    pub stdout: Vec<u8>,
 }
 
 impl std::fmt::Debug for Errored {


### PR DESCRIPTION
This is needed to implement something like `Run` as a user-defined flag.

Also, clarify the polarity of `test_condition`.

# TODO (check if already done)
* [ ] Add tests -> does not seem needed?
* [x] Add CHANGELOG.md entry
* [ ] Bumped minor version and committed lockfiles in case a release is desired
* [ ] check if you used AI on this PR
