### PR TITLE
DependencyBuilder: fix bless_lockfile behavior

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -87,12 +87,9 @@ fn build_dependencies_inner(
         }
     }
 
-    // Reusable closure for setting up the environment both for artifact generation and `cargo_metadata`
-    let set_locking = |cmd: &mut Command| {
-        if !info.bless_lockfile {
-            cmd.arg("--locked");
-        }
-    };
+    if !info.bless_lockfile {
+        build.arg("--locked");
+    }
 
     build.arg("--message-format=json");
 
@@ -242,7 +239,6 @@ fn build_dependencies_inner(
         .arg("--manifest-path")
         .arg(&info.crate_manifest_path);
     info.program.apply_env(&mut metadata);
-    set_locking(&mut metadata);
     let output = config.run_command(&mut metadata)?;
 
     if !output.status.success() {

--- a/tests/integrations/dep-fail/Cargo.stdout
+++ b/tests/integrations/dep-fail/Cargo.stdout
@@ -7,7 +7,7 @@ Building dependencies ... FAILED
 tests/ui/basic_test.rs ... FAILED
 
 FAILED TEST: tests/ui/basic_test.rs
-command: "$CMD" "build" "--color=never" "--quiet" "--jobs" "1" "--target-dir" "$DIR/tests/integrations/dep-fail/target/ui/0" "--manifest-path" "tested_crate/Cargo.toml"  "--message-format=json"
+command: "$CMD" "build" "--color=never" "--quiet" "--jobs" "1" "--target-dir" "$DIR/tests/integrations/dep-fail/target/ui/0" "--manifest-path" "tested_crate/Cargo.toml"  "--locked" "--message-format=json"
 
 full stderr:
 error: could not compile `tested_crate` (lib) due to 1 previous error


### PR DESCRIPTION
The dependency builder currently always blesses the lockfile, no matter what `bless_lockfile` says: the first invocation (that does the actual build) is never done with `--locked`. The 2nd invocation (for the metadata) uses `--locked` but at that point the lockfile has already been updated.

Only the first invocation needs the flag (if the lockfile is outdated it will fail).